### PR TITLE
Feature: Platzhalter‑Renderer (Sub‑Issue #20)

### DIFF
--- a/src/template_python_projekt/render.py
+++ b/src/template_python_projekt/render.py
@@ -1,7 +1,8 @@
-"""Ein kleines Rendering-Hilfsmodul für Template-Dokumentation.
+"""Rendering helpers for templates used in the project.
 
-Versucht, `jinja2` zu importieren; falls nicht vorhanden, wird ein einfacher
-`string.Template`-Fallback verwendet.
+This module prefers `jinja2` when available; otherwise it falls back to a
+small, well-scoped regexp-based subset to support common `{{ var }}` and
+`{{ var | default('value') }}` patterns used in the templates.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ try:
     import jinja2
 
     _jinja2: Any | None = jinja2
-except ImportError:
+except ImportError:  # pragma: no cover - import fallback
     _jinja2 = None
 
 
@@ -47,7 +48,7 @@ def render_template_file(path: str | Path, context: dict[str, Any]) -> str:
         return ""
 
     pattern: re.Pattern[str] = re.compile(
-        r"\{\{\s*(?P<name>[A-Za-z0-9_]+)\s*(?:\|\s*default\((['\"])(?P<default>.*?)\2\)\s*)?\}\}",
+        r"\{\{\s*(?P<name>[A-Za-z0-9_]+)\s*(?:\|\s*default\((['\"]) (?P<default>.*?)\2\)\s*)?\}\}",
     )
     result = pattern.sub(_replace, text)
     # Any remaining simple {{ var }} without default will be replaced by empty string
@@ -61,8 +62,6 @@ def render_directory(path: str | Path, context: dict[str, Any]) -> dict[str, str
     :func:`render_template_file` and returns a dictionary where keys are
     POSIX-style relative paths (as strings) and values are the rendered file
     contents.
-
-    This helper is useful for testing templates without writing output files.
     """
     root = Path(path)
     if not root.exists():
@@ -76,3 +75,6 @@ def render_directory(path: str | Path, context: dict[str, Any]) -> dict[str, str
         rel = p.relative_to(root).as_posix()
         rendered[rel] = render_template_file(p, context)
     return rendered
+
+
+__all__ = ["render_directory", "render_template_file"]

--- a/tests/test_template_renderer.py
+++ b/tests/test_template_renderer.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_render_template_file(tmp_path: Path) -> None:
+    from template_python_projekt.render import render_template_file
+
+    tpl = tmp_path / "tpl"
+    tpl.mkdir()
+    f = tpl / "greeting.txt"
+    f.write_text("Hello {{name}}!\n")
+
+    out = render_template_file(f, {"name": "Bob"})
+    assert out == "Hello Bob!\n"
+
+
+def test_render_directory_mapping(tmp_path: Path) -> None:
+    from template_python_projekt.render import render_directory
+
+    tpl = tmp_path / "tpl"
+    tpl.mkdir()
+    (tpl / "a.txt").write_text("A: {{a}}")
+    (tpl / "sub").mkdir()
+    (tpl / "sub" / "b.txt").write_text("B: {{b}}")
+
+    rendered = render_directory(tpl, {"a": "1", "b": "2"})
+    assert rendered["a.txt"] == "A: 1"
+    assert rendered["sub/b.txt"] == "B: 2"


### PR DESCRIPTION
## Zusammenfassung

Implementiert einen einfachen Platzhalter‑Renderer mit Jinja2‑Fallback.

## Änderungen
- Neu: `src/template_python_projekt/render.py` (Renderer + Jinja2‑Fallback)
- Tests: `tests/test_template_renderer.py`

## Akzeptanzkriterien
- [ ] `poetry run ruff check .` läuft ohne Fehler
- [ ] `poetry run mypy src` läuft ohne Fehler
- [ ] Relevante Tests (`tests/test_template_renderer.py`) sind grün

## Testanweisungen
```bash
poetry run ruff check .
poetry run mypy src
pytest -q tests/test_template_renderer.py
```

## Verwandte Issues
- Parent: #4
- Dieses PR schließt: #20
