### PR TITLE
Feature: Node/markdownlint-Erkennung

### DIFF
--- a/src/template_python_projekt/node_env.py
+++ b/src/template_python_projekt/node_env.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import shutil
+
+
+def ensure_node_and_markdownlint(*, run_install: bool = False) -> tuple[bool, str]:
+    """Prüft, ob `node` und ein `markdownlint`-CLI vorhanden sind.
+
+    Rückgabe: `(ok, nachricht)`
+    - ok = True: Node ist vorhanden; wenn `markdownlint` nicht gefunden wurde,
+      enthält die Nachricht eine Anleitung zur Installation (kein automatisches
+      Installieren).
+    - ok = False: Node nicht gefunden.
+
+    Der Helper führt keine automatischen `npm`-Installationen aus, sondern gibt
+    handlungsorientierte Hinweise zurück.
+    """
+    # `run_install` kept for API parity with other helpers; nicht automatisch verwenden
+    _ = run_install
+
+    node_path = shutil.which("node")
+    if node_path is None:
+        return (
+            False,
+            (
+                "node wurde nicht gefunden. Bitte installiere Node.js (z.B. von "
+                "https://nodejs.org/) oder stelle sicher, dass 'node' im PATH liegt."
+            ),
+        )
+
+    # Prüfe auf bekannte CLI-Namen für markdownlint
+    md_cli = shutil.which("markdownlint") or shutil.which("markdownlint-cli")
+    if md_cli:
+        return (True, f"Node gefunden unter: {node_path}. markdownlint gefunden unter: {md_cli}.")
+
+    # Wenn markdownlint fehlt, geben wir eine Anleitung zurück.
+    install_msg = (
+        "Node wurde gefunden. 'markdownlint' (markdownlint-cli) wurde nicht gefunden.\n"
+        "Installationsoptionen:\n"
+        "- Global (sofort nutzbar): `npm install -g markdownlint-cli`\n"
+        "- Projekt/DevDependency: Füge "
+        '  "markdownlint-cli": "^0.XX" zu `devDependencies` in `package.json` hinzu'
+        " und führe `npm install` aus.\n"
+        "Ich führe keine Installation automatisch aus; führe einen der obigen Befehle manuell aus."
+    )
+
+    return (True, install_msg)

--- a/tests/test_node_env.py
+++ b/tests/test_node_env.py
@@ -1,0 +1,38 @@
+import shutil
+
+import pytest
+
+from template_python_projekt.node_env import ensure_node_and_markdownlint
+
+
+def test_node_missing(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    ok, msg = ensure_node_and_markdownlint(run_install=False)
+    assert ok is False
+    assert "node wurde nicht gefunden" in msg
+
+
+def test_node_present_but_no_md(monkeypatch):
+    def fake_which(name: str):
+        if name == "node":
+            return "/usr/bin/node"
+        return None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    ok, msg = ensure_node_and_markdownlint(run_install=False)
+    assert ok is True
+    assert "markdownlint" in msg
+
+
+def test_node_and_md_present(monkeypatch):
+    def fake_which(name: str):
+        if name == "node":
+            return "/usr/bin/node"
+        if name == "markdownlint":
+            return "/usr/bin/markdownlint"
+        return None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    ok, msg = ensure_node_and_markdownlint(run_install=False)
+    assert ok is True
+    assert "markdownlint gefunden" in msg


### PR DESCRIPTION
## Zusammenfassung
Prüft lokal, ob Node.js installiert ist und ob ein `markdownlint`-CLI vorhanden ist.
Der Helper gibt handlungsorientierte Installationshinweise zurück und führt keine
automatischen `npm`-Installationen aus.

## Änderungen
- Neuer Helper: `src/template_python_projekt/node_env.py`
- Unit‑Tests: `tests/test_node_env.py`

## Akzeptanzkriterien
- [ ] Node.js erkannt, wenn installiert
- [ ] Meldung enthält klare Installationsanweisungen, falls `markdownlint` fehlt
- [ ] Unit‑Tests lokal grün

## Testanweisungen
```bash
poetry run ruff check .
poetry run mypy .
pytest -q tests/test_node_env.py
```

## Verwandte Issues
- Parent: #4
- Dieses PR schließt: #23
