### PR TITLE
Docs: Quickstart — Link zu manueller Initialisierung (Issue #31)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,3 +79,7 @@ Nächste Schritte
 
 - Ergänze diesen Quickstart mit Screenshots, Beispielausgaben und
   optionalen CI‑Skripten zum Smoke‑Test.
+
+- Siehe auch die detaillierte Anleitung zur manuellen Initialisierung:
+  [Manuelle Initialisierung](manual_initialization.md) — reproduziert das
+  Verhalten des Starterskripts Schritt für Schritt (Issue #31).


### PR DESCRIPTION
Fügt einen Link in docs/quickstart.md auf docs/manual_initialization.md hinzu (Issue #31).