### PR TITLE
Issue 33: Contribution-Guide für Templates hinzufügen

### DIFF
--- a/.github/ISSUE-33.md
+++ b/.github/ISSUE-33.md
@@ -1,0 +1,33 @@
+# Issue 33 — Contribution‑Guide: Wie fügt man neue Templates / Anpassungen hinzu
+
+- **Repo:** Eichi76/Template-Python-Projekt
+- **Issue‑Nummer:** 33
+- **Titel:** Contribution‑Guide: Wie fügt ich neue Templates / Anpassungen hinzu
+- **Author:** Eichi76
+- **Assignees:** Eichi76
+- **Estimate:** 6h
+- **Tags / Dependencies:** feature-project-templates
+
+## Acceptance Criteria
+- `CONTRIBUTING.md` definiert Prozess, Tests zum Ausführen, Template‑Metadata‑Schema und eine PR‑Checklist.
+
+## Hinweise
+- PRs für diese Änderung sollen gegen den Parent‑Branch `issue/5` geöffnet werden.
+- Branch‑Namenskonvention für Sub‑Issues: `issue/5-33-<short>` (Vorschlag: `issue/5-33-contrib-guide`).
+- Lokale Checks:
+  - `poetry run ruff check .`
+  - `poetry run mypy .`
+  - `pre-commit run --all-files`
+  - `pytest -q --cov=src --cov-report=xml`
+
+## Aktionsliste
+- [x] Issue‑Details abrufen (Titel, Body, AC, Estimate, Tags)
+- [ ] Worktree prüfen und Branch erstellen
+- [ ] Implementierung (erstelle/ändere `CONTRIBUTING.md`, ggf. Templates/Tests)
+- [ ] Linting, Typprüfung und Tests ausführen
+- [ ] Commits und Pre‑commit Checks
+- [ ] Branch pushen und PR erstellen
+- [ ] Nach dem Merge aufräumen
+
+## Quelle
+Issue‑Daten via MCP: `title`, `body`, `comments`, `assignees`, `author`, `estimate`.

--- a/.github/prompts/plan-contribGuide.prompt.md
+++ b/.github/prompts/plan-contribGuide.prompt.md
@@ -1,0 +1,89 @@
+Plan: Sub-Issue 33 Umsetzung
+
+TL;DR
+Erstelle einen Sub‑Branch von `issue/5` namens `issue/5-33-contrib-guide`; implementiere einen `CONTRIBUTING.md`, passe Tests an, fixe Lint/Type/Pre‑commit, pushe und eröffne erst bei Fertigstellung einen PR gegen `issue/5`.
+
+Schritte
+
+1. Issue‑Details holen
+   - PowerShell: `gh issue view 33 --repo Eichi76/Template-Python-Projekt --json title,body,comments`
+   - Notiere Titel, Acceptance Criteria, Estimate, Tags/Dependencies.
+
+2. Worktree prüfen & Branch anlegen
+   - `git fetch`
+   - `git checkout issue/5`
+   - `git pull --ff-only origin issue/5`
+   - Branch erstellen: `git checkout -b issue/5-33-contrib-guide`
+
+3. Implementieren
+   - Erstelle/ändere `CONTRIBUTING.md` gemäß Acceptance Criteria: Prozess, Tests, Template‑Metadata‑Schema, PR‑Checklist.
+   - Falls nötig, ergänze/aktualisiere Template‑Vorlagen in `project_templates/`.
+   - Ergänze oder passe Tests in `tests/` an, die das Verhalten absichern.
+
+4. Lokale Qualitätssicherung (iterativ)
+   - Ruff: `poetry run ruff check .` → Fehler/Warnungen beheben.
+   - Mypy: `poetry run mypy .` → Typfehler beheben (repo verlangt `disallow_untyped_defs = true`).
+   - Pre‑commit: `pre-commit run --all-files` → Hooks ausführen und Probleme fixen.
+   - Tests: `pytest -q --cov=src --cov-report=xml` → Tests grün.
+   - Iteriere bis alle Checks grün sind.
+
+5. Commits
+   - Kleine, thematische Commits mit klaren Nachrichten.
+   - Pre‑commit Hooks laufen beim Commit — behebe auftretende Warnungen vor Push.
+
+6. Push & PR (erst wenn fertig)
+   - Push: `git push -u origin issue/5-33-contrib-guide`
+   - PR erstellen gegen `issue/5` (kein Draft):
+     - Deutscher Titel, z. B. „Issue 33: Contribution‑Guide für Templates hinzufügen“
+     - Ausführliche Beschreibung: Motivation, Änderungen, Tests, Migrationsschritte, Follow‑ups, Verweis auf Issue #33.
+   - PR Merge: Squash‑Merge nach eigener Prüfung (kein weiterer Reviewer nötig).
+
+7. Nach dem Merge
+   - `git checkout issue/5 && git pull`
+   - `git branch -d issue/5-33-contrib-guide`
+
+Relevante Dateien
+- `pyproject.toml` — Python‑Version, `mypy`/`ruff` Einstellungen.
+- `.pre-commit-config.yaml` — Hooks (ruff/isort/mypy).
+- `.github/workflows/ci.yml` — CI‑Python‑Version und Actions.
+- `project_templates/` — Template‑Vorlagen.
+- `src/template_python_projekt/` — Starter/Renderer Code (bei Bedarf anpassen).
+- `tests/` — Tests anpassen/erweitern.
+
+Verifikation
+1. `poetry run ruff check .` → keine Errors/Warnungen.
+2. `poetry run mypy .` → keine Typfehler.
+3. `pre-commit run --all-files` → alle Hooks grün.
+4. `pytest -q --cov=src --cov-report=xml` → alle Tests grün.
+
+PowerShell Kurzbefehle
+```powershell
+# Issue Info holen
+gh issue view 33 --repo Eichi76/Template-Python-Projekt --json title,body,comments
+
+# Branch erstellen
+git fetch
+git checkout issue/5
+git pull --ff-only origin issue/5
+git checkout -b issue/5-33-contrib-guide
+
+# Qualität & Tests
+poetry run ruff check .
+poetry run mypy .
+pre-commit run --all-files
+pytest -q --cov=src --cov-report=xml
+
+# Push
+git push -u origin issue/5-33-contrib-guide
+
+# PR (gh)
+gh pr create --base issue/5 --title "Issue 33: Contribution‑Guide für Templates hinzufügen" --body "<ausführliche Beschreibung>" --repo Eichi76/Template-Python-Projekt
+```
+
+Entscheidungen / Annahmen
+- PRs werden gegen `issue/5` gemerged.
+- Kein Reviewprozess nötig — du mergest selbst.
+- Branchname: `issue/5-33-contrib-guide`.
+
+Nächste Schritte
+- Auf Wunsch erzeuge ich den Branch lokal oder bereite die PR‑Beschreibung vor.

--- a/.github/prompts/plan-issue32FaqTroubleshooting.prompt.md
+++ b/.github/prompts/plan-issue32FaqTroubleshooting.prompt.md
@@ -1,0 +1,117 @@
+## Plan: Issue #32 umsetzen (FAQ / Troubleshooting)
+
+TL;DR: Erstelle eine Troubleshooting‑/FAQ‑Seite mit den Top‑10-Warnfällen (poetry/node/pre-commit/merge conflicts etc.), verlinke sie in der Dokumentation, füge einen simplen Test hinzu, arbeite auf einem Sub‑Branch von `issue/5` und schließe mit einer deutschen PR‑Beschreibung und Squash‑Merge ab.
+
+**Akzeptanzkriterien (aus Issue #32)**
+- FAQ deckt mindestens die Top‑10 wahrscheinlichen Fehler ab (z. B. `poetry` fehlt, `node` fehlt, `pre-commit` schlägt fehl, Merge‑Konflikte).
+- Dokument ist in `docs/` verfügbar und von der `docs/README.md` referenziert.
+
+**Steps (detailliert)**
+1. Issue‑Kontext bestätigen (bereits abgerufen)
+   - Issue: "Troubleshooting & FAQ für häufige Probleme" (Estimate: 4h).
+   - Acceptance Criteria beachten: Top‑10 Fälle dokumentieren.
+
+2. Sub‑Branch erstellen (vom Parent `issue/5`)
+   - Fetch & Checkout:
+
+```bash
+git fetch origin
+git checkout origin/issue/5 -b issue/5-32-faq-troubleshooting
+```
+
+   - Push erst, wenn du bereit bist zu teilen (`git push -u origin issue/5-32-faq-troubleshooting`).
+
+3. Struktur & Inhalte erstellen
+   - Neue Datei: `docs/troubleshooting.md` (oder `docs/faq.md`). Inhalt:
+     - Kurzbeschreibung / Zweck
+     - Top‑10 Fehler (je Abschnitt: Symptom, Ursache, Lösung/Workaround, relevante Befehle)
+     - Hinweise zu Debugging (Logs, `--verbose` flags, typische Pfade)
+     - Verweise auf `pyproject.toml`, `pre-commit`, `poetry`, `node`, und Git‑Merge Tipps
+   - Update: `docs/README.md` → Link / Abschnitt "Troubleshooting / FAQ".
+   - Optional: `README.md` Kurzverweis (wenn sinnvoll).
+
+4. Tests hinzufügen
+   - Neuer Test: `tests/test_troubleshooting_doc.py` mit einfachen Checks:
+     - Datei `docs/troubleshooting.md` existiert
+     - Enthält Headings/Keywords (`poetry`, `node`, `pre-commit`, `merge`) — einfache substring asserts
+   - Beispiel (pytest): prüfe `Path('docs/troubleshooting.md').read_text()` enthält erwartete Strings.
+
+5. Lokale Validierung & Qualitätssicherung
+   - Markdown sanity: `markdownlint` falls vorhanden (repo hat `test_markdownlint_template.py`).
+   - Lint & Typecheck für den Code (nicht für docs):
+
+```bash
+poetry run ruff check .
+poetry run mypy .
+```
+
+   - Tests ausführen:
+
+```bash
+pytest -q --cov=src --cov-report=xml
+```
+
+   - Pre‑commit Hooks:
+
+```bash
+pre-commit run --all-files
+```
+
+   - Behebe auftretende Warnungen/Fehler bevor commit/push.
+
+6. Commits & Commit‑Konvention
+   - Kleine, thematische Commits (z. B. `docs: add troubleshooting/faq skeleton`, `docs: add node/poetry preflight steps`, `tests: add doc presence tests`).
+   - Achte auf pre-commit Auto‑Fixes; passe Commit‑Messages an falls Hooks fehlschlagen.
+
+7. PR Erstellung (erst nach Abschluss aller Checks)
+   - PR nicht als Draft.
+   - Deutscher Titel, z. B.: `Docs: Issue #32 – Troubleshooting & FAQ für häufige Probleme`
+   - Ausführliche PR‑Beschreibung (Deutsch):
+     - Kurzfassung der Änderungen
+     - Vollständige Liste der Top‑10 Fehler, die dokumentiert wurden
+     - Verlinkte Dateien: `docs/troubleshooting.md`, `docs/README.md`, evtl. `README.md`
+     - Test‑Summary (neue Tests, Befehle zum Ausführen)
+     - Hinweise: Lint/MyPy/Pre‑commit Status
+   - PR erstellen mit `gh`:
+
+```bash
+gh pr create --base main --head issue/5-32-faq-troubleshooting --title "Docs: Issue #32 – Troubleshooting & FAQ für häufige Probleme" --body "<ausführliche Beschreibung in Deutsch>"
+```
+
+   - Keine Reviewer required (Single‑Person Team). Tags/Milestone setzen falls gewünscht.
+
+8. Merge & Cleanup
+   - Nach finaler Prüfung Squash‑Merge.
+   - Beispiel mit `gh`:
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch
+```
+
+   - Lokal aufräumen: `git checkout issue/5` ; `git branch -D issue/5-32-faq-troubleshooting`.
+
+**Relevante Dateien / Stellen**
+- `docs/troubleshooting.md` — neu: die FAQ/ Troubleshooting Seite
+- `docs/README.md` — Link/Navigation aktualisieren
+- `README.md` — optionaler Kurzverweis
+- Tests: `tests/test_troubleshooting_doc.py` — neuer Test
+- `pyproject.toml` — zeigt Linting/Typechecker Befehle (siehe `dependency-groups`)
+
+**Verification (konkret)**
+1. Datei vorhanden: `tests/test_troubleshooting_doc.py` besteht und `pytest -q` läuft durch
+2. Inhalte: `docs/troubleshooting.md` enthält die Schlüsselwörter `poetry`, `node`, `pre-commit`, `merge`
+3. Lint/MyPy: `poetry run ruff check .` und `poetry run mypy .` ohne neue Warnungen (für Code)
+4. Pre-commit: `pre-commit run --all-files` → alle Hooks grün
+5. PR‑Beschreibung auf Deutsch, inkl. How‑to‑verify-Anleitung
+
+**Aufwandsabschätzung**
+- Gemäß Issue: ~4 Stunden (Erfassen der Top‑10, Schreiben der Abschnitte, Tests, PR‑Erstellung)
+
+**Entscheidungen / Annahmen**
+- Dokumentation in `docs/` ist ausreichend; kein neues CLI‑Feature notwendig.
+- Tests prüfen grundlegende Präsenz und Schlüsselwörter, keine semantische Validierung der Lösungen.
+- PRs werden erst erstellt, wenn alle lokalen Checks bestanden sind.
+
+**Nächste Schritte (Empfohlen)**
+1. Bestätige, dass ich die Datei `docs/troubleshooting.md` anlegen soll (ich kann sie scaffolden).
+2. Wenn ja: Soll ich direkt ein erstes Commit/Branch erstellen oder möchtest du lokal prüfen bevor Push/PR?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contribution Guide
+
+Dieses Dokument beschreibt, wie Beiträge zu diesem Repository eingereicht,
+getestet und gemerged werden sollen. Ziel ist ein reproduzierbarer Prozess
+für neue Templates und Anpassungen an bestehenden Templates.
+
+## Kurzer Workflow
+
+- Basis‑Branch für Feature‑Arbeit: `issue/5` (Sub‑Branches im Format
+  `issue/5-<num>-<short>`).
+- Erstelle lokalen Branch, implementiere Änderungen, sorge dafür, dass alle
+  Checks grün sind und öffne erst dann einen Pull Request gegen `issue/5`.
+- PR‑Titel auf Deutsch, Merge per Squash‑Merge.
+- Single‑Person‑Team: keine weiteren Reviewer nötig.
+
+## Branching
+
+- Hole zuerst den aktuellen Parent‑Branch:
+
+```powershell
+git fetch
+git checkout issue/5
+git pull --ff-only origin issue/5
+git checkout -b issue/5-33-contrib-guide
+```
+
+Ersetze `33` und `contrib-guide` entsprechend Issue‑Nummer und kurzer
+Beschreibung.
+
+## Tests & lokale Checks
+
+Führe vor Commits und Pushs stets die folgenden Befehle aus:
+
+```powershell
+# Lint
+poetry run ruff check .
+
+# Typechecking
+poetry run mypy .
+
+# Pre-commit Hooks (lokal)
+pre-commit run --all-files
+
+# Tests
+pytest -q --cov=src --cov-report=xml
+```
+
+Wenn ein Check fehlschlägt, behebe die Fehler lokal und wiederhole die
+Befehle. Commits sollten die Hooks passieren (pre-commit ist konfiguriert).
+
+## Template‑Metadata‑Schema (Empfehlung)
+
+Neue oder geänderte Templates sollten eine kurze Metadaten‑Sektion (YAML)
+enthalten, die vom Renderer erwartet wird. Beispiel (`template.yaml`):
+
+```yaml
+name: "cli-basic"
+version: "0.1.0"
+description: "Minimal template für CLI‑Projekte"
+author: "Your Name <mail@example.com>"
+tags:
+  - cli
+  - basic
+compatibility:
+  python: ">=3.12,<3.13"
+tests:
+  - "pytest"
+```
+
+Dokumentiere alle erforderlichen Metafelder in der jeweiligen
+Template‑README.
+
+## PR‑Checklist (für die Beschreibung)
+
+Eine PR Beschreibung muss mindestens enthalten:
+
+- Deutschen Titel, z. B. „Issue 33: Contribution‑Guide für Templates
+  hinzufügen“
+- Kurze Zusammenfassung der Änderungen
+- Motivation / Problem, das gelöst wird
+- Akzeptanzkriterien (siehe Issue #33)
+- Liste der ausgeführten Checks (ruff, mypy, pre-commit, pytest) und deren
+  Status
+- Hinweise zur manuellen Verifikation (Schritte, Dateien zu prüfen)
+- Falls relevant: Migrationsschritte, Breaking Changes, Follow‑ups
+
+Beispiel `gh`‑Befehl zum Erstellen des PRs (erst ausführen, wenn alles grün
+ist):
+
+```powershell
+gh pr create --base issue/5 --title "Issue 33: Contribution‑Guide für
+Templates hinzufügen" --body "<ausführliche Beschreibung>" --repo
+Eichi76/Template-Python-Projekt
+```
+
+## Commit‑Konventionen
+
+- Schreibe klare Commit‑Nachrichten; gruppiere Änderungen thematisch.
+- Pre‑commit Hooks laufen beim Commit; falls Hooks Fehler melden, behebe
+  diese vor Push.
+
+## Verantwortlichkeit & Review
+
+- Da dieses Repo als Single‑Person‑Team geführt wird, genügt die eigene
+  Prüfung; PRs werden nach eigener Abnahme per Squash‑Merge zusammengeführt.
+
+## Fragen
+
+Bei Rückfragen oder Unklarheiten verweise auf Issue #33 oder öffne ein
+kurzes Issue/PR‑Kommentar.


### PR DESCRIPTION
Kurzbeschreibung

Dieser Pull Request fügt einen Contribution‑Guide (`CONTRIBUTING.md`) hinzu, der beschreibt,
wie neue Templates erstellt werden, welche Tests und Checks lokal auszuführen sind und wie
PRs zu verfassen sind. Ziel ist, den Prozess zum Hinzufügen oder Anpassen von Templates zu
vereinheitlichen und reproduzierbar zu machen.

Motivation

Das Repository benötigt klare Vorgaben für Contributor, insbesondere für Template‑Autoren,
um Fehler zu vermeiden und sicherzustellen, dass CI/Checks konsistent ausgeführt werden.

Änderungen

- Hinzugefügt: `CONTRIBUTING.md` mit Workflow, Branch‑Konvention, Tests/Checks,
  Template‑Metadata‑Schema und PR‑Checklist.
- Hinzugefügt: `.github/ISSUE-33.md` mit Issue‑Metadaten.
- Hinzugefügt: `.github/prompts/plan-contribGuide.prompt.md` (Plan/Entwurf).

Akzeptanzkriterien

- `CONTRIBUTING.md` definiert Prozess, Tests zum Ausführen, Template‑Metadata‑Schema und
  eine PR‑Checklist. (Siehe Issue #33)

Ausgeführte Checks (lokal)

- `poetry run ruff check .` — Passed
- `poetry run mypy .` — Passed
- `pre-commit run --all-files` — Passed
- `poetry run pytest -q --cov=src --cov-report=xml` — 23 passed

Verifikation / How to test locally

1. Checkout des Branches:

```powershell
git fetch
git checkout issue/5-33-contrib-guide
```

2. Lokale Checks ausführen:

```powershell
poetry run ruff check .
poetry run mypy .
pre-commit run --all-files
poetry run pytest -q --cov=src --cov-report=xml
```

3. Inhalte von `CONTRIBUTING.md` prüfen und ggf. Feedback als Kommentar im Issue #33 hinterlassen.

Merge‑Strategie

- Merge per `squash` in `issue/5` nach eigener Prüfung.

Weitere Hinweise

- Dieses Repo wird als Single‑Person‑Team betrieben; daher sind keine externen Reviewer
  erforderlich. Bei Rückfragen bitte Issue #33 verwenden.
