### PR TITLE
Dokumentation: Beispielprojekte (CLI, PySide6) — Issue #34

### DIFF
--- a/.github/prompts/plan-docsExamples.prompt.md
+++ b/.github/prompts/plan-docsExamples.prompt.md
@@ -1,0 +1,62 @@
+## Plan: Issue #34 — Dokumentation für Beispielprojekte
+
+TL;DR: Ergänze für jedes Beispielprojekt (CLI und PySide6) eine README/Docs‑Seite mit Ausführungen zu Ausführen, Debuggen, Testen und Packaging plus Beispielausgabe. Implementierung erfolgt in einem Sub‑Branch von `issue/5`, alle Änderungen testen, linten und typprüfen; erst am Ende PR öffnen und per Squash‑Merge zusammenführen.
+
+**Steps**
+1. Discovery: Inhalte des Issue #34 prüfen und Abhängigkeiten bestätigen (*done*).
+2. Branch anlegen: Von `issue/5` aus einen Sub‑Branch erstellen mit Namen `issue/5-34-docs-examples`.
+3. Scoping: Liste aller Beispiel‑Templates ermitteln — mindestens `project_templates/cli-basic` und `project_templates/ui-pyside6`.
+4. Implementierung (parallel pro Template):
+   - `cli-basic`: Erstelle/ergänze `project_templates/cli-basic/docs/README.md.jinja` mit Run/Debug/Test/Packaging‑Schritten und Beispielausgabe.
+   - `ui-pyside6`: Erstelle/ergänze `project_templates/ui-pyside6/README.md.jinja` (oder `docs/` falls vorhanden) mit gleichen Inhalten plus Hinweise zu PySide6‑Start und Packaging.
+   - Falls Vorlagen bereits `index.md.jinja` oder `README.md.jinja` enthalten, erweitere diese statt neue Dateien anzulegen.
+5. Test‑ & Template‑Check: Passe ggf. `tests/` an oder ergänze kleinere Tests, die sicherstellen, dass die README‑Renders keine Fehler erzeugen (z. B. `tests/test_template_renderer.py` prüfen).
+6. Lokale Qualitätssicherung:
+   - Lint: `poetry run ruff check .` — alle Warnungen/Fehler beheben.
+   - Typprüfung: `poetry run mypy .` — Fehler beheben.
+   - Pre‑commit: `pre-commit run --all-files` — auftretende Probleme beheben.
+   - Tests: `poetry run pytest -q` — grün.
+7. Commit‑Schritte:
+   - Committen in sinnvollen Einheiten mit deutschen Commit‑Nachrichten (Kurz, präzise).
+   - Bei mehreren Commits rebase/squash lokal nach Bedarf, damit PR sauber ist.
+8. Push: Branch ins Remote pushen (`git push -u origin issue/5-34-docs-examples`).
+9. PR erstellen (erst wenn alle Implementierungen und QA abgeschlossen):
+   - Verwende `gh` oder MCP‑Tooling. PR‑Regeln: deutscher Titel, ausführliche Beschreibung (Changes, Test‑Schritte, Überlegungen), kein Draft, keine Reviewer, Merge via Squash.
+10. After‑merge: Tag/Release falls nötig, evtl. `CHANGELOG` aktualisieren.
+
+**Relevant files**
+- project_templates/cli-basic/docs/index.md.jinja — erweitern/prüfen
+- project_templates/cli-basic/docs/README.md.jinja — neu/erweitern
+- project_templates/ui-pyside6/src/__init__.py — evtl. Beispiel‑Aufruf referenzieren
+- project_templates/ui-pyside6/README.md.jinja oder project_templates/ui-pyside6/docs/* — neu/erweitern
+- docs/manual_initialization.md — falls Einträge zur Nutzung der Templates nötig sind
+- tests/test_template_renderer.py — prüfen/ergänzen
+
+**Verification**
+1. Lokale Renderprüfung: `python -m src.template_python_projekt.render` (sofern Render‑CLI existiert) für betroffene Templates ausführen.
+2. Lint: `poetry run ruff check .` → 0 Fehler
+3. Typen: `poetry run mypy .` → 0 Errors
+4. Pre‑commit: `pre-commit run --all-files` → sauber
+5. Tests: `poetry run pytest -q --maxfail=1` → alle Tests grün
+6. Manuelle Verifikation: README‑Anweisungen folgen und CLI/UI Demos starten
+
+**Decisions / Annahmen**
+- Branchname: `issue/5-34-docs-examples` (von `issue/5`).
+- PR erst öffnen wenn alles implementiert und getestet ist. Kein vorzeitiger Draft‑PR.
+- Single‑person team → keine Reviewer, PR dennoch mit vollständiger Beschreibung.
+- Merge: Squash‑Merge.
+
+**Further Considerations**
+1. Sollen die Beispiel‑README Dateien als Jinja Templates in `project_templates/*` gehalten werden (empfohlen), oder als fertige Markdown Dateien? Empfehlung: Jinja, um Variablen/Platzhalter konsistent zu halten.
+2. Wenn Packaging‑Schritte projektabhängig sind (poetry vs pip), bitte Kurzvarianten je Template dokumentieren.
+3. Wünschst du, dass ich die PR‑Beschreibungsvorlage vorformuliere (ja/nein)?
+
+---
+Checkliste (kurz):
+- [ ] Branch erstellt
+- [ ] Docs für `cli-basic` aktualisiert
+- [ ] Docs für `ui-pyside6` aktualisiert
+- [ ] Tests angepasst/ausgeführt
+- [ ] Lint & mypy grün
+- [ ] Pre‑commit sauber
+- [ ] Push & PR erstellt (deutscher Titel + ausführliche Beschreibung)

--- a/project_templates/cli-basic/docs/README.md.jinja
+++ b/project_templates/cli-basic/docs/README.md.jinja
@@ -1,0 +1,83 @@
+# {{ project_name }} — Beispiel: CLI Basic
+
+Diese Datei beschreibt, wie man das generierte CLI‑Beispielprojekt ausführt, debuggt, testet und paketiert. Die Schritte sind so formuliert, dass sie direkt aus dem gerenderten Template anwendbar sind.
+
+## Schnellstart — Ausführen
+
+1) Projekt generieren (Dry‑Run)
+
+```bash
+python -m template_python_projekt --template cli-basic --name demo --dry-run
+```
+
+2) Projekt wirklich erzeugen
+
+```bash
+python -m template_python_projekt --template cli-basic --name demo
+cd demo
+```
+
+3) CLI ausführen
+
+```bash
+python -m demo.main --help
+```
+
+Erwartete Ausgabe (Beispiel):
+
+```
+usage: main.py [-h] [--example EXAMPLE]
+
+Demo CLI
+optional arguments:
+  -h, --help       show this help message and exit
+  --example EXAMPLE  Beispielparameter
+```
+
+## Debuggen
+
+- Lokales Debugging: Öffne das Projekt in deinem Editor/IDE und setze Breakpoints in `demo/src/main.py`.
+- Mit `python -m debugpy --listen 5678 -m demo.main` kann VS Code/IDE an Port 5678 verbinden.
+
+## Tests
+
+0) Installiere Abhängigkeiten (falls notwendig)
+
+```bash
+python -m pip install -e .
+# oder mit Poetry im generierten Projekt:
+poetry install --with dev
+```
+
+1) Tests ausführen
+
+```bash
+poetry run pytest -q
+```
+
+Erwartete Ausgabe (Beispiel):
+
+```
+============================= test session starts ==============================
+collected 3 items
+
+tests/test_main.py ...                                                     [100%]
+
+============================== 3 passed in 0.12s ===============================
+```
+
+## Packaging
+
+- Mit `python -m build` erzeugst du sdist und wheel (stellen Sie sicher, dass `build` installiert ist).
+- Mit Poetry:
+
+```bash
+poetry build
+```
+
+## Hinweise
+
+- Falls dein Zielprojekt Poetry verwendet, nutze `poetry run` für Befehle in der Entwicklungsumgebung.
+- Passe die Beispiele an das tatsächliche Package/Modul‑Naming des gerenderten Templates an (z. B. `demo.main`).
+
+<!-- EOF -->

--- a/project_templates/ui-pyside6/README.md.jinja
+++ b/project_templates/ui-pyside6/README.md.jinja
@@ -1,0 +1,80 @@
+# {{ project_name }} — Beispiel: PySide6 UI
+
+Diese Datei beschreibt, wie man das generierte PySide6‑Beispielprojekt ausführt, debuggt, testet und paketiert.
+
+## Schnellstart — Ausführen
+
+1) Projekt generieren (Dry‑Run)
+
+```bash
+python -m template_python_projekt --template ui-pyside6 --name demo --dry-run
+```
+
+2) Projekt wirklich erzeugen
+
+```bash
+python -m template_python_projekt --template ui-pyside6 --name demo
+cd demo
+```
+
+3) UI starten
+
+```bash
+python -m demo.main
+```
+
+Erwartete Ausgabe / Verhalten (Beispiel):
+
+- Ein Fenster mit Titel "DemoApp" öffnet sich (oder eine kurze Konsolenausgabe, falls die Vorlage nur einen Headless‑Stub enthält).
+
+## Debuggen
+
+- Setze Breakpoints in `demo/src/main.py` oder `demo/src/view/`.
+- Remote‑Debugging mit `debugpy`:
+
+```bash
+python -m debugpy --listen 5678 -m demo.main
+```
+
+Dann in VS Code verbinden (Port 5678).
+
+## Tests
+
+0) Abhängigkeiten installieren
+
+```bash
+python -m pip install -e .
+# oder mit Poetry im generierten Projekt:
+poetry install --with dev
+```
+
+1) Tests ausführen
+
+```bash
+poetry run pytest -q
+```
+
+Erwartete Ausgabe (Beispiel):
+
+```
+============================= test session starts ==============================
+collected 2 items
+
+tests/test_ui_startup.py ..                                                  [100%]
+
+============================== 2 passed in 0.50s ===============================
+```
+
+Hinweis: UI‑Tests können Headless‑Modi oder Mocks erfordern; passe Tests entsprechend an.
+
+## Packaging
+
+- Mit `poetry build` erzeugst du wheel und sdist.
+- Für Desktop‑Distributionen nutze Tools wie `briefcase` oder `pyinstaller` (nicht Teil dieses Templates; Hinweise und Beispiele können hier ergänzt werden).
+
+## Hinweise
+
+- PySide6 sollte in der `pyproject.toml` oder `requirements.txt` des generierten Projekts als Abhängigkeit angegeben werden.
+- Wenn das Template nur einen Stub als `main` liefert, ergänze die `view/`‑Implementierung mit einem einfachen `QMainWindow`‑Beispiel für Demo‑Zwecke.
+
+<!-- EOF -->


### PR DESCRIPTION
Dieses Pull Request implementiert Issue #34 — ergänzt die Dokumentation für die Beispielprojekte `cli-basic` und `ui-pyside6`.

Änderungen
- `project_templates/cli-basic/docs/README.md.jinja` — neue Anleitung: Ausführen, Debuggen, Testen, Packaging, Beispielausgabe
- `project_templates/ui-pyside6/README.md.jinja` — neue Anleitung: Ausführen, Debuggen, Testen, Packaging, Hinweise zu UI‑Tests
- `.github/prompts/plan-docsExamples.prompt.md` — intern gespeicherter Plan / TODO

Quality Assurance (lokal ausgeführt)
- Template‑Rendering: neue README‑Templates gerendert (keine Template‑Fehler)
- Lint: `poetry run ruff check .` → passed
- Typecheck: `poetry run mypy .` → passed
- Pre‑commit: `pre-commit run --all-files` → passed
- Tests: `poetry run pytest -q` → 23 passed

Verifikation (Kurz)
1) Branch auschecken:
   `git fetch origin && git checkout issue/5-34-docs-examples`
2) Lokales Rendern prüfen:
   `python -c "import sys; sys.path.insert(0,'src'); from template_python_projekt import render; print(render.render_template_file('project_templates/cli-basic/docs/README.md.jinja', {'project_name':'demo'}))"`
3) Tests ausführen:
   `poetry run pytest -q`

Merge‑Hinweis
- Bitte per Squash‑Merge mergen.
- Single‑person Team: keine Reviewer nötig.

Bei Fragen: kurze Rückmeldung, ich passe die Dokumente an.