### PR TITLE
Issue 5: Anleitung — Quickstart, manuelle Initialisierung und Troubleshooting

### DIFF
--- a/.github/ISSUE-33.md
+++ b/.github/ISSUE-33.md
@@ -1,0 +1,33 @@
+# Issue 33 — Contribution‑Guide: Wie fügt man neue Templates / Anpassungen hinzu
+
+- **Repo:** Eichi76/Template-Python-Projekt
+- **Issue‑Nummer:** 33
+- **Titel:** Contribution‑Guide: Wie fügt ich neue Templates / Anpassungen hinzu
+- **Author:** Eichi76
+- **Assignees:** Eichi76
+- **Estimate:** 6h
+- **Tags / Dependencies:** feature-project-templates
+
+## Acceptance Criteria
+- `CONTRIBUTING.md` definiert Prozess, Tests zum Ausführen, Template‑Metadata‑Schema und eine PR‑Checklist.
+
+## Hinweise
+- PRs für diese Änderung sollen gegen den Parent‑Branch `issue/5` geöffnet werden.
+- Branch‑Namenskonvention für Sub‑Issues: `issue/5-33-<short>` (Vorschlag: `issue/5-33-contrib-guide`).
+- Lokale Checks:
+  - `poetry run ruff check .`
+  - `poetry run mypy .`
+  - `pre-commit run --all-files`
+  - `pytest -q --cov=src --cov-report=xml`
+
+## Aktionsliste
+- [x] Issue‑Details abrufen (Titel, Body, AC, Estimate, Tags)
+- [ ] Worktree prüfen und Branch erstellen
+- [ ] Implementierung (erstelle/ändere `CONTRIBUTING.md`, ggf. Templates/Tests)
+- [ ] Linting, Typprüfung und Tests ausführen
+- [ ] Commits und Pre‑commit Checks
+- [ ] Branch pushen und PR erstellen
+- [ ] Nach dem Merge aufräumen
+
+## Quelle
+Issue‑Daten via MCP: `title`, `body`, `comments`, `assignees`, `author`, `estimate`.

--- a/.github/prompts/plan-contribGuide.prompt.md
+++ b/.github/prompts/plan-contribGuide.prompt.md
@@ -1,0 +1,89 @@
+Plan: Sub-Issue 33 Umsetzung
+
+TL;DR
+Erstelle einen Sub‑Branch von `issue/5` namens `issue/5-33-contrib-guide`; implementiere einen `CONTRIBUTING.md`, passe Tests an, fixe Lint/Type/Pre‑commit, pushe und eröffne erst bei Fertigstellung einen PR gegen `issue/5`.
+
+Schritte
+
+1. Issue‑Details holen
+   - PowerShell: `gh issue view 33 --repo Eichi76/Template-Python-Projekt --json title,body,comments`
+   - Notiere Titel, Acceptance Criteria, Estimate, Tags/Dependencies.
+
+2. Worktree prüfen & Branch anlegen
+   - `git fetch`
+   - `git checkout issue/5`
+   - `git pull --ff-only origin issue/5`
+   - Branch erstellen: `git checkout -b issue/5-33-contrib-guide`
+
+3. Implementieren
+   - Erstelle/ändere `CONTRIBUTING.md` gemäß Acceptance Criteria: Prozess, Tests, Template‑Metadata‑Schema, PR‑Checklist.
+   - Falls nötig, ergänze/aktualisiere Template‑Vorlagen in `project_templates/`.
+   - Ergänze oder passe Tests in `tests/` an, die das Verhalten absichern.
+
+4. Lokale Qualitätssicherung (iterativ)
+   - Ruff: `poetry run ruff check .` → Fehler/Warnungen beheben.
+   - Mypy: `poetry run mypy .` → Typfehler beheben (repo verlangt `disallow_untyped_defs = true`).
+   - Pre‑commit: `pre-commit run --all-files` → Hooks ausführen und Probleme fixen.
+   - Tests: `pytest -q --cov=src --cov-report=xml` → Tests grün.
+   - Iteriere bis alle Checks grün sind.
+
+5. Commits
+   - Kleine, thematische Commits mit klaren Nachrichten.
+   - Pre‑commit Hooks laufen beim Commit — behebe auftretende Warnungen vor Push.
+
+6. Push & PR (erst wenn fertig)
+   - Push: `git push -u origin issue/5-33-contrib-guide`
+   - PR erstellen gegen `issue/5` (kein Draft):
+     - Deutscher Titel, z. B. „Issue 33: Contribution‑Guide für Templates hinzufügen“
+     - Ausführliche Beschreibung: Motivation, Änderungen, Tests, Migrationsschritte, Follow‑ups, Verweis auf Issue #33.
+   - PR Merge: Squash‑Merge nach eigener Prüfung (kein weiterer Reviewer nötig).
+
+7. Nach dem Merge
+   - `git checkout issue/5 && git pull`
+   - `git branch -d issue/5-33-contrib-guide`
+
+Relevante Dateien
+- `pyproject.toml` — Python‑Version, `mypy`/`ruff` Einstellungen.
+- `.pre-commit-config.yaml` — Hooks (ruff/isort/mypy).
+- `.github/workflows/ci.yml` — CI‑Python‑Version und Actions.
+- `project_templates/` — Template‑Vorlagen.
+- `src/template_python_projekt/` — Starter/Renderer Code (bei Bedarf anpassen).
+- `tests/` — Tests anpassen/erweitern.
+
+Verifikation
+1. `poetry run ruff check .` → keine Errors/Warnungen.
+2. `poetry run mypy .` → keine Typfehler.
+3. `pre-commit run --all-files` → alle Hooks grün.
+4. `pytest -q --cov=src --cov-report=xml` → alle Tests grün.
+
+PowerShell Kurzbefehle
+```powershell
+# Issue Info holen
+gh issue view 33 --repo Eichi76/Template-Python-Projekt --json title,body,comments
+
+# Branch erstellen
+git fetch
+git checkout issue/5
+git pull --ff-only origin issue/5
+git checkout -b issue/5-33-contrib-guide
+
+# Qualität & Tests
+poetry run ruff check .
+poetry run mypy .
+pre-commit run --all-files
+pytest -q --cov=src --cov-report=xml
+
+# Push
+git push -u origin issue/5-33-contrib-guide
+
+# PR (gh)
+gh pr create --base issue/5 --title "Issue 33: Contribution‑Guide für Templates hinzufügen" --body "<ausführliche Beschreibung>" --repo Eichi76/Template-Python-Projekt
+```
+
+Entscheidungen / Annahmen
+- PRs werden gegen `issue/5` gemerged.
+- Kein Reviewprozess nötig — du mergest selbst.
+- Branchname: `issue/5-33-contrib-guide`.
+
+Nächste Schritte
+- Auf Wunsch erzeuge ich den Branch lokal oder bereite die PR‑Beschreibung vor.

--- a/.github/prompts/plan-docsExamples.prompt.md
+++ b/.github/prompts/plan-docsExamples.prompt.md
@@ -1,0 +1,62 @@
+## Plan: Issue #34 — Dokumentation für Beispielprojekte
+
+TL;DR: Ergänze für jedes Beispielprojekt (CLI und PySide6) eine README/Docs‑Seite mit Ausführungen zu Ausführen, Debuggen, Testen und Packaging plus Beispielausgabe. Implementierung erfolgt in einem Sub‑Branch von `issue/5`, alle Änderungen testen, linten und typprüfen; erst am Ende PR öffnen und per Squash‑Merge zusammenführen.
+
+**Steps**
+1. Discovery: Inhalte des Issue #34 prüfen und Abhängigkeiten bestätigen (*done*).
+2. Branch anlegen: Von `issue/5` aus einen Sub‑Branch erstellen mit Namen `issue/5-34-docs-examples`.
+3. Scoping: Liste aller Beispiel‑Templates ermitteln — mindestens `project_templates/cli-basic` und `project_templates/ui-pyside6`.
+4. Implementierung (parallel pro Template):
+   - `cli-basic`: Erstelle/ergänze `project_templates/cli-basic/docs/README.md.jinja` mit Run/Debug/Test/Packaging‑Schritten und Beispielausgabe.
+   - `ui-pyside6`: Erstelle/ergänze `project_templates/ui-pyside6/README.md.jinja` (oder `docs/` falls vorhanden) mit gleichen Inhalten plus Hinweise zu PySide6‑Start und Packaging.
+   - Falls Vorlagen bereits `index.md.jinja` oder `README.md.jinja` enthalten, erweitere diese statt neue Dateien anzulegen.
+5. Test‑ & Template‑Check: Passe ggf. `tests/` an oder ergänze kleinere Tests, die sicherstellen, dass die README‑Renders keine Fehler erzeugen (z. B. `tests/test_template_renderer.py` prüfen).
+6. Lokale Qualitätssicherung:
+   - Lint: `poetry run ruff check .` — alle Warnungen/Fehler beheben.
+   - Typprüfung: `poetry run mypy .` — Fehler beheben.
+   - Pre‑commit: `pre-commit run --all-files` — auftretende Probleme beheben.
+   - Tests: `poetry run pytest -q` — grün.
+7. Commit‑Schritte:
+   - Committen in sinnvollen Einheiten mit deutschen Commit‑Nachrichten (Kurz, präzise).
+   - Bei mehreren Commits rebase/squash lokal nach Bedarf, damit PR sauber ist.
+8. Push: Branch ins Remote pushen (`git push -u origin issue/5-34-docs-examples`).
+9. PR erstellen (erst wenn alle Implementierungen und QA abgeschlossen):
+   - Verwende `gh` oder MCP‑Tooling. PR‑Regeln: deutscher Titel, ausführliche Beschreibung (Changes, Test‑Schritte, Überlegungen), kein Draft, keine Reviewer, Merge via Squash.
+10. After‑merge: Tag/Release falls nötig, evtl. `CHANGELOG` aktualisieren.
+
+**Relevant files**
+- project_templates/cli-basic/docs/index.md.jinja — erweitern/prüfen
+- project_templates/cli-basic/docs/README.md.jinja — neu/erweitern
+- project_templates/ui-pyside6/src/__init__.py — evtl. Beispiel‑Aufruf referenzieren
+- project_templates/ui-pyside6/README.md.jinja oder project_templates/ui-pyside6/docs/* — neu/erweitern
+- docs/manual_initialization.md — falls Einträge zur Nutzung der Templates nötig sind
+- tests/test_template_renderer.py — prüfen/ergänzen
+
+**Verification**
+1. Lokale Renderprüfung: `python -m src.template_python_projekt.render` (sofern Render‑CLI existiert) für betroffene Templates ausführen.
+2. Lint: `poetry run ruff check .` → 0 Fehler
+3. Typen: `poetry run mypy .` → 0 Errors
+4. Pre‑commit: `pre-commit run --all-files` → sauber
+5. Tests: `poetry run pytest -q --maxfail=1` → alle Tests grün
+6. Manuelle Verifikation: README‑Anweisungen folgen und CLI/UI Demos starten
+
+**Decisions / Annahmen**
+- Branchname: `issue/5-34-docs-examples` (von `issue/5`).
+- PR erst öffnen wenn alles implementiert und getestet ist. Kein vorzeitiger Draft‑PR.
+- Single‑person team → keine Reviewer, PR dennoch mit vollständiger Beschreibung.
+- Merge: Squash‑Merge.
+
+**Further Considerations**
+1. Sollen die Beispiel‑README Dateien als Jinja Templates in `project_templates/*` gehalten werden (empfohlen), oder als fertige Markdown Dateien? Empfehlung: Jinja, um Variablen/Platzhalter konsistent zu halten.
+2. Wenn Packaging‑Schritte projektabhängig sind (poetry vs pip), bitte Kurzvarianten je Template dokumentieren.
+3. Wünschst du, dass ich die PR‑Beschreibungsvorlage vorformuliere (ja/nein)?
+
+---
+Checkliste (kurz):
+- [ ] Branch erstellt
+- [ ] Docs für `cli-basic` aktualisiert
+- [ ] Docs für `ui-pyside6` aktualisiert
+- [ ] Tests angepasst/ausgeführt
+- [ ] Lint & mypy grün
+- [ ] Pre‑commit sauber
+- [ ] Push & PR erstellt (deutscher Titel + ausführliche Beschreibung)

--- a/.github/prompts/plan-issue32FaqTroubleshooting.prompt.md
+++ b/.github/prompts/plan-issue32FaqTroubleshooting.prompt.md
@@ -1,0 +1,117 @@
+## Plan: Issue #32 umsetzen (FAQ / Troubleshooting)
+
+TL;DR: Erstelle eine Troubleshooting‑/FAQ‑Seite mit den Top‑10-Warnfällen (poetry/node/pre-commit/merge conflicts etc.), verlinke sie in der Dokumentation, füge einen simplen Test hinzu, arbeite auf einem Sub‑Branch von `issue/5` und schließe mit einer deutschen PR‑Beschreibung und Squash‑Merge ab.
+
+**Akzeptanzkriterien (aus Issue #32)**
+- FAQ deckt mindestens die Top‑10 wahrscheinlichen Fehler ab (z. B. `poetry` fehlt, `node` fehlt, `pre-commit` schlägt fehl, Merge‑Konflikte).
+- Dokument ist in `docs/` verfügbar und von der `docs/README.md` referenziert.
+
+**Steps (detailliert)**
+1. Issue‑Kontext bestätigen (bereits abgerufen)
+   - Issue: "Troubleshooting & FAQ für häufige Probleme" (Estimate: 4h).
+   - Acceptance Criteria beachten: Top‑10 Fälle dokumentieren.
+
+2. Sub‑Branch erstellen (vom Parent `issue/5`)
+   - Fetch & Checkout:
+
+```bash
+git fetch origin
+git checkout origin/issue/5 -b issue/5-32-faq-troubleshooting
+```
+
+   - Push erst, wenn du bereit bist zu teilen (`git push -u origin issue/5-32-faq-troubleshooting`).
+
+3. Struktur & Inhalte erstellen
+   - Neue Datei: `docs/troubleshooting.md` (oder `docs/faq.md`). Inhalt:
+     - Kurzbeschreibung / Zweck
+     - Top‑10 Fehler (je Abschnitt: Symptom, Ursache, Lösung/Workaround, relevante Befehle)
+     - Hinweise zu Debugging (Logs, `--verbose` flags, typische Pfade)
+     - Verweise auf `pyproject.toml`, `pre-commit`, `poetry`, `node`, und Git‑Merge Tipps
+   - Update: `docs/README.md` → Link / Abschnitt "Troubleshooting / FAQ".
+   - Optional: `README.md` Kurzverweis (wenn sinnvoll).
+
+4. Tests hinzufügen
+   - Neuer Test: `tests/test_troubleshooting_doc.py` mit einfachen Checks:
+     - Datei `docs/troubleshooting.md` existiert
+     - Enthält Headings/Keywords (`poetry`, `node`, `pre-commit`, `merge`) — einfache substring asserts
+   - Beispiel (pytest): prüfe `Path('docs/troubleshooting.md').read_text()` enthält erwartete Strings.
+
+5. Lokale Validierung & Qualitätssicherung
+   - Markdown sanity: `markdownlint` falls vorhanden (repo hat `test_markdownlint_template.py`).
+   - Lint & Typecheck für den Code (nicht für docs):
+
+```bash
+poetry run ruff check .
+poetry run mypy .
+```
+
+   - Tests ausführen:
+
+```bash
+pytest -q --cov=src --cov-report=xml
+```
+
+   - Pre‑commit Hooks:
+
+```bash
+pre-commit run --all-files
+```
+
+   - Behebe auftretende Warnungen/Fehler bevor commit/push.
+
+6. Commits & Commit‑Konvention
+   - Kleine, thematische Commits (z. B. `docs: add troubleshooting/faq skeleton`, `docs: add node/poetry preflight steps`, `tests: add doc presence tests`).
+   - Achte auf pre-commit Auto‑Fixes; passe Commit‑Messages an falls Hooks fehlschlagen.
+
+7. PR Erstellung (erst nach Abschluss aller Checks)
+   - PR nicht als Draft.
+   - Deutscher Titel, z. B.: `Docs: Issue #32 – Troubleshooting & FAQ für häufige Probleme`
+   - Ausführliche PR‑Beschreibung (Deutsch):
+     - Kurzfassung der Änderungen
+     - Vollständige Liste der Top‑10 Fehler, die dokumentiert wurden
+     - Verlinkte Dateien: `docs/troubleshooting.md`, `docs/README.md`, evtl. `README.md`
+     - Test‑Summary (neue Tests, Befehle zum Ausführen)
+     - Hinweise: Lint/MyPy/Pre‑commit Status
+   - PR erstellen mit `gh`:
+
+```bash
+gh pr create --base main --head issue/5-32-faq-troubleshooting --title "Docs: Issue #32 – Troubleshooting & FAQ für häufige Probleme" --body "<ausführliche Beschreibung in Deutsch>"
+```
+
+   - Keine Reviewer required (Single‑Person Team). Tags/Milestone setzen falls gewünscht.
+
+8. Merge & Cleanup
+   - Nach finaler Prüfung Squash‑Merge.
+   - Beispiel mit `gh`:
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch
+```
+
+   - Lokal aufräumen: `git checkout issue/5` ; `git branch -D issue/5-32-faq-troubleshooting`.
+
+**Relevante Dateien / Stellen**
+- `docs/troubleshooting.md` — neu: die FAQ/ Troubleshooting Seite
+- `docs/README.md` — Link/Navigation aktualisieren
+- `README.md` — optionaler Kurzverweis
+- Tests: `tests/test_troubleshooting_doc.py` — neuer Test
+- `pyproject.toml` — zeigt Linting/Typechecker Befehle (siehe `dependency-groups`)
+
+**Verification (konkret)**
+1. Datei vorhanden: `tests/test_troubleshooting_doc.py` besteht und `pytest -q` läuft durch
+2. Inhalte: `docs/troubleshooting.md` enthält die Schlüsselwörter `poetry`, `node`, `pre-commit`, `merge`
+3. Lint/MyPy: `poetry run ruff check .` und `poetry run mypy .` ohne neue Warnungen (für Code)
+4. Pre-commit: `pre-commit run --all-files` → alle Hooks grün
+5. PR‑Beschreibung auf Deutsch, inkl. How‑to‑verify-Anleitung
+
+**Aufwandsabschätzung**
+- Gemäß Issue: ~4 Stunden (Erfassen der Top‑10, Schreiben der Abschnitte, Tests, PR‑Erstellung)
+
+**Entscheidungen / Annahmen**
+- Dokumentation in `docs/` ist ausreichend; kein neues CLI‑Feature notwendig.
+- Tests prüfen grundlegende Präsenz und Schlüsselwörter, keine semantische Validierung der Lösungen.
+- PRs werden erst erstellt, wenn alle lokalen Checks bestanden sind.
+
+**Nächste Schritte (Empfohlen)**
+1. Bestätige, dass ich die Datei `docs/troubleshooting.md` anlegen soll (ich kann sie scaffolden).
+2. Wenn ja: Soll ich direkt ein erstes Commit/Branch erstellen oder möchtest du lokal prüfen bevor Push/PR?

--- a/.github/prompts/plan-issue35MakeCheck.prompt.md
+++ b/.github/prompts/plan-issue35MakeCheck.prompt.md
@@ -1,0 +1,91 @@
+## Plan: Issue #35 — "make check" Validierungsziel
+
+TL;DR: Implementiere ein `make check` Ziel (oder äquivalentes Script) im Repo-Root, das nacheinander `poetry env check`, `pytest -q`, `pre-commit run --all-files` und optional `npm run lint:md` ausführt. Erzeuge einen Sub-Branch von `issue/5` namens `issue/5-35-make-check`. Verifiziere lokal Linting (`poetry run ruff check .`), Typprüfung (`poetry run mypy .`) und Pre-commit-Hooks; behebe Warnungen; öffne erst nach vollständiger Implementierung einen PR mit deutschem Titel und ausführlicher Beschreibung; merge per Squash.
+
+**Schritte**
+1. Vorbereitung
+- Lokales Repo auf aktuellen `issue/5` bringen: `git fetch && git checkout issue/5 && git pull`.
+- Erstelle Sub-Branch: `git checkout -b issue/5-35-make-check` (*depends on step 1*).
+
+2. Implementieren: `make check`
+- Im Repo-Root eine `Makefile` (oder `scripts/check.sh` + `Makefile`-Target) hinzufügen/erweitern.
+- Implementiere Target `check` mit folgenden Schritten in dieser Reihenfolge:
+  - `poetry env check` (prüft Poetry/Environment)
+  - `poetry run pytest -q` (Tests)
+  - `pre-commit run --all-files`
+  - Optional: `npm run lint:md` (nur wenn `package.json` / node‑Linter für Markdown vorhanden)
+- Stelle sicher, dass jedes Kommando bei Fehler non-zero zurückgibt, damit `make check` bei Fehlern stoppt.
+
+3. Tests & Anpassungen
+- Falls Tests fehlschlagen: Tests anpassen oder Issue spezifisch fixen (Tests müssen grün laufen).
+- Falls Pre-commit-Hooks Warnungen ausgeben: Code gemäß Hooks anpassen (Automatisieren, falls möglich).
+- Falls `npm run lint:md` in `project_templates/common` oder Root nicht existiert: dokumentiere optionales Flag oder skip mit Info im Makefile.
+
+4. Linting & Typing
+- Führe `poetry run ruff check .` aus und behebe Warnungen.
+- Führe `poetry run mypy .` aus und behebe Typfehler/Unannotated-Defs.
+- Achte auf `pyproject.toml` mypy/ruff Einstellungen (z. B. `line-length`, `disallow_untyped_defs`).
+
+5. Commit, Pre-commit & Push
+- Committe Änderungen atomar, mit klaren Messages (z. B. `Add make check target + docs`).
+- Führe `pre-commit run --all-files` lokal; behebe verbleibende Issues.
+- Push Branch: `git push --set-upstream origin issue/5-35-make-check`.
+
+6. Pull Request
+- Öffne PR gegen `issue/5` (NOT gegen `main`).
+- PR-Regeln: kein Draft-PRs; erst öffnen, wenn alles implementiert und alle Checks grün.
+- PR-Namen (Deutsch): `Issue #35: "make check" Ziel hinzufügen — Validierungs-Workflow`.
+- PR-Beschreibung: ausführliche deutsche Beschreibung mit
+  - Kontext (Issue #35 verlinken)
+  - Was geändert wurde (Makefile, evtl. scripts, Tests, docs)
+  - Wie lokal geprüft (Befehle und erwartetes Verhalten)
+  - Acceptance Criteria / Checkliste (als ToDo-Liste) mit Haken
+  - Hinweis: Merge-Strategie: Squash-Merge; keine Reviewer erforderlich (single-person team)
+
+7. Merge & Aufräumen
+- Nach finaler Verifikation: Squash-Merge PR in `issue/5`.
+- Lokales Aufräumen: `git checkout issue/5 && git pull` und `git branch -d issue/5-35-make-check` und `git push origin --delete issue/5-35-make-check` (optional).
+
+**Relevante Dateien / Orte zum Anpassen**
+- `Makefile` (neu/erweitern) — Root
+- `scripts/check.sh` (optional) — Root
+- `pyproject.toml` — (prüfen / dokumentieren) Root
+- `src/template_python_projekt/__main__.py` oder `main.py` — nur falls CLI-Entrypoints angepasst werden sollen
+- `project_templates/common/package.json.jinja` oder `project_templates/*/package.json.jinja` — falls `npm run lint:md` referenziert werden soll
+- `.pre-commit-config` oder `pyproject.toml` (pre-commit hooks) — sicherstellen, dass Hooks vorhanden und dokumentiert sind
+- `tests/` — ggf. neue Tests oder Anpassungen
+
+**Verification (konkrete Befehle, in Backticks)**
+- `git checkout issue/5 && git pull`
+- `git checkout -b issue/5-35-make-check`
+- `make check` → gesamter Workflow muss erfolgreich durchlaufen
+- `poetry run ruff check .` → keine Warnungen
+- `poetry run mypy .` → keine Fehler
+- `poetry run pytest -q` → alle Tests grün
+- `pre-commit run --all-files` → keine Fehler
+
+**PR-Vorlage (Deutsch)**
+- Titel: `Issue #35: "make check" Ziel hinzufügen — Validierungs-Workflow`
+- Beschreibung:
+  - Kurzbeschreibung des Problems und weshalb `make check` nötig ist.
+  - Liste der durchgeführten Änderungen (Dateipfade).
+  - Anleitung zur lokalen Prüfung (s. Verification-Befehle).
+  - Acceptance-Criteria (Checkboxen):
+    - [ ] `make check` führt `poetry env check` aus
+    - [ ] `make check` führt `pytest -q` aus
+    - [ ] `make check` führt `pre-commit run --all-files` aus
+    - [ ] Optional: `npm run lint:md` ausgeführt oder dokumentiert
+  - Merge-Hinweis: Squash‑Merge, kein externer Reviewer benötigt.
+
+**Entscheidungen & Annahmen**
+- Branch von `issue/5` erstellen (wie gefordert).
+- Branch-Name: `issue/5-35-make-check` (Nummer = Issue Nummer 35, Kurz = `make-check`).
+- Keine Draft-PRs; PR erst öffnen, wenn alle Checks grün sind.
+- Single-person team → keine Reviewer, PR trotzdem mit ausführlicher Beschreibung.
+- `npm run lint:md` ist optional und nur aktiviert, wenn `package.json` bzw. Linter konfiguriert ist.
+
+**Weiteres / Offene Fragen**
+1. Soll `make check` zwingend `npm run lint:md` ausführen, oder soll das optional/conditional sein? Empfehlung: optional aufgrund heterogener Repos.
+2. Möchtest du ein separates `scripts/check.sh`-Script, das von `Makefile` aufgerufen wird (besser für Windows/PowerShell-Kompatibilität), oder reicht ein reines `Makefile`-Target? Empfehlung: beides — `Makefile` ruft `scripts/check.ps1`/`scripts/check.sh` je nach Plattform.
+
+Speichere ich diesen Plan jetzt in `/memories/session/plan.md` (geschehen). Möchtest du, dass ich jetzt das `Makefile`-Patch vorschlage und die Änderungen in einem Branch implementiere (nur Planmodus: ich kann den nächsten Schritt planen oder, mit Freigabe, implementieren)?

--- a/.github/prompts/plan-migrationAndUpdates.prompt.md
+++ b/.github/prompts/plan-migrationAndUpdates.prompt.md
@@ -1,0 +1,55 @@
+## Plan: Migration & Updates (Issue #36)
+
+TL;DR - Erstelle eine Dokumentationsseite mit einer sicheren Update-/Migrations‑Checkliste, Beispiele für Migrationen in Templates, und ergänze den Renderer um eine nicht-interaktive "Update Existing"-Strategie plus Tests. Umsetzung erfolgt in einem Sub-Branch von `issue/5` namens `issue/5-36-migration`.
+
+**Steps**
+1. Discovery (bereits durchgeführt): Zusammenstellung relevanter Dateien, Lücken: Docs, Renderer, Templates, Tests.
+2. Branch: Erstelle lokalen Branch `issue/5-36-migration` von `issue/5`. (*blocks: none*)
+3. Documentation: Neue Seite `docs/migration_and_updates.md` anlegen mit:
+   - Einleitung, Risiken, Backup-Hinweis
+   - Schritt-für-Schritt Checkliste (Backup, Abhängigkeiten prüfen, Tests laufen lassen, Änderungen anwenden, Konflikt-Handling)
+   - Konkrete Beispiele: Update `pyproject.toml`, Merge-Muster für `README.md` und `src`-Änderungen
+   - Troubleshooting-Abschnitt
+   (Depends on step 2)
+4. Templates: Ergänze `project_templates/common/` und `project_templates/cli-basic/` um Beispiel-Abschnitte oder `migration_examples/`-Vorlagen für typische Update‑Szenarien (z. B. `pyproject.toml`-Änderung). (Parallel mit 3)
+5. CLI/Renderer: Implementiere eine nicht-interaktive Update-Strategie in [src/template_python_projekt/render.py](src/template_python_projekt/render.py):
+   - Neue Option/Parameter `update_mode` mit Strategien: `skip`, `overwrite`, `backup` (default `backup`)
+   - Beim Rendern bestehender Dateien: erst in Temp schreiben, dann je nach Strategie handeln (backup vorhandener Datei `.bak.TIMESTAMP`, oder skip)
+   - Exponiere Option in [src/template_python_projekt/main.py](src/template_python_projekt/main.py) CLI, dokumentiere Usage in `docs/migration_and_updates.md`.
+   (Depends on step 2)
+6. Tests: Füge Tests hinzu:
+   - `tests/test_migration_docs.py` — Validiert Inhalte/Links der neuen Doc-Seite
+   - `tests/test_render_update_mode.py` — Unit-Tests für `render.py` Update-Strategien (simulate existing file, assert backup/overwrite/skip behavior)
+   (Depends on step 5)
+7. Lint & Typecheck: Vor jedem Commit `poetry run ruff check .` und `poetry run mypy .` ausführen; Warnungen beheben.
+8. Pre-commit: Achte auf pre-commit-Hooks; falls sie Fehler/Warnungen melden, beheben bevor push.
+9. Commit & Push: Committe lokal in logischen Einzelschritten (Docs, Templates, Renderer, Tests). Push branch `issue/5-36-migration`.
+10. PR: Erstelle nach Abschluss einen Pull Request (kein Draft). PR-Name auf Deutsch (z. B. "Migration: Migrations‑Leitfaden und sichere Update‑Strategie"), ausführliche Beschreibung (Summary, was geändert wurde, How to test, Test-Commands, Merge-Strategie: squash). Keine weiteren Reviewer nötig. (Depends on step 9)
+11. Merge: Nach QA per `squash-merge` in `issue/5` oder `main` wie vereinbart.
+
+**Relevant files**
+- [docs/manual_initialization.md](docs/manual_initialization.md) — Referenz: bestehende Init-Anweisungen
+- [docs/quickstart.md](docs/quickstart.md) — Referenz für Examples
+- [docs/troubleshooting.md](docs/troubleshooting.md) — erweitern mit Migration-Troubles
+- [src/template_python_projekt/render.py](src/template_python_projekt/render.py) — Renderer-Änderung (Update-Strategie)
+- [src/template_python_projekt/main.py](src/template_python_projekt/main.py) — CLI-Flag
+- [project_templates/common/pyproject.toml.jinja](project_templates/common/pyproject.toml.jinja) — Beispiel-Migration
+- [project_templates/cli-basic/docs/README.md.jinja](project_templates/cli-basic/docs/README.md.jinja) — Beispiel-Docs
+
+**Verification**
+1. Dokumentation: `poetry run pytest -q tests/test_migration_docs.py` (neue Tests grün)
+2. Renderer behavior: `poetry run pytest -q tests/test_render_update_mode.py` (backup/overwrite/skip verified)
+3. Lint & Typecheck: `poetry run ruff check .` → 0 Issues; `poetry run mypy .` → 0 Errors
+4. Full test-suite: `poetry run pytest -q` passes
+
+**Decisions / Annahmen**
+- CLI-Update-Strategie ist nicht interaktiv (keine Prompts), da CI/automatisierte Runs benötigt werden.
+- Backup statt überschreiben als default, um Sicherheit zu maximieren.
+- Branch-Name: `issue/5-36-migration` (Sub-Issue 36)
+- Pull Request: Deutsche Titel & ausführliche Beschreibung, Merge per `squash`.
+
+**Further Considerations**
+1. Möchtest du die Update-Strategie als dominante CLI-Option (`--update`/`--no-update`) oder als Konfig in `pyproject.toml`? Empfehlung: CLI-Flag + Dokumentation.
+2. Soll ein opt-in Auto-merge-Tool für einfache textuelle Dateien (README/pyproject) implementiert werden? Option B: nur Backup + manuelles Merge.
+
+*Geschätzter Aufwand*: ca. 6h (wie im Issue angegeben) — aufgeteilt: Docs 2h, Renderer 2.5h, Tests 1h, Integration 0.5h.

--- a/.github/prompts/plan-parentIssueFive.prompt.md
+++ b/.github/prompts/plan-parentIssueFive.prompt.md
@@ -1,0 +1,137 @@
+## Plan: Parent Issue #5 umsetzen
+
+TL;DR - Ziel: Parent Issue #5 durch sequenzielle Abarbeitung der Sub‑Issues #29–#36 umsetzen. Ansatz: Für jedes Sub‑Issue lokal einen Branch `issue/5-<num>-<short>` anlegen, Änderungen vollständig abschließen, Lint/Typecheck/Tests grün bekommen, erst dann einen PR gegen `issue/5` eröffnen und nach Abschluss mergen. Reihenfolge: 29 → 30 → 31 → 32 → 33 → 34 → 35 → 36.
+
+**Steps**
+1. Basis: erstelle lokalen Parent‑Branch `issue/5` von `main`.
+2. Für jedes Sub‑Issue (in Reihenfolge) führe die folgenden Schritte sequenziell aus:
+   - a) Branch anlegen: `git checkout -b issue/5-<num>-<short>` (erst unmittelbar bevor du mit dem Sub‑Issue beginnst).
+   - b) Implementieren: Änderungen in relevanten Dateien vornehmen.
+   - c) Lokale Checks: `poetry run ruff check .`, `poetry run mypy .`, `pytest -q`.
+   - d) Pre‑commit: `git add` + `git commit` — falls pre‑commit fehlschlägt, alle Linter/Formatter Probleme beheben und erneut committen.
+   - e) Push: `git push -u origin issue/5-<num>-<short>`.
+   - f) PR öffnen (mit `gh pr create` oder über Web): Ziel-Branch `issue/5`. Kein Draft‑PR; erst öffnen wenn Sub‑Issue komplett.
+   - g) PR Titel (Deutsch) und ausführliche Beschreibung (siehe PR‑Template unten).
+   - h) Merge nach erfolgreichem Durchlaufen der CI und Tests: `Squash and merge` empfohlen, Merge in `issue/5`.
+   - i) Lokaler `git checkout issue/5` → `git pull` um den gemergten Stand zu aktualisieren.
+3. Nach Abschluss aller Sub‑Issues: finaler PR von `issue/5` → `main` erstellen, Tests/Linting ausführen, in `main` mergen.
+
+**Branch‑Namensschema**
+- Parent: `issue/5`
+- Sub‑Issues: `issue/5-29-quickstart`, `issue/5-30-cli-docs`, `issue/5-31-manual-init`, `issue/5-32-troubleshooting`, `issue/5-33-contributing`, `issue/5-34-examples-docs`, `issue/5-35-postinit-check`, `issue/5-36-migration-updates`.
+
+**PR Titel & Beschreibung (Vorlage)**
+- PR Titel (Deutsch): „ISSUE #<num>: <kurzer deutscher Titel>"
+- PR Beschreibung (ausführlich):
+  - Kurzbeschreibung: Was wurde geändert und warum.
+  - Dateien: Liste der geänderten kritischen Dateien.
+  - Checkliste:
+    - [ ] Lokale Linting: `poetry run ruff check .` erfolgreich
+    - [ ] Typechecking: `poetry run mypy .` erfolgreich
+    - [ ] Tests: `pytest -q` alle grünen
+    - [ ] Pre‑commit Hooks laufen durch
+    - [ ] Änderungen dokumentiert (Docs/README oder gezielte MD)
+  - Testing‑Anleitung (Kurz): Befehle zum lokalen Verifizieren.
+  - Merge‑Hinweis: `Squash and merge` in `issue/5` nach CI‑Grün, kein Reviewer erforderlich (single‑person team).
+
+**Verifikation (je Sub‑Issue)**
+- Lint: `poetry run ruff check .`
+- Typecheck: `poetry run mypy .`
+- Tests: `pytest -q --maxfail=1`
+- Pre‑commit lokal: `pre-commit run --all-files` (wenn installiert)
+- CI: `.github/workflows/ci.yml` sollte nach Änderung erfolgreich durchlaufen.
+
+**Relevante Dateien (überblicksweise, referenziert in Issue‑Analyse)**
+- [src/template_python_projekt/main.py](src/template_python_projekt/main.py)
+- [src/template_python_projekt/render.py](src/template_python_projekt/render.py)
+- [src/template_python_projekt/node_env.py](src/template_python_projekt/node_env.py)
+- [src/template_python_projekt/poetry_env.py](src/template_python_projekt/poetry_env.py)
+- [scripts/validate_templates.py](scripts/validate_templates.py)
+- [docs/README.md](docs/README.md)
+- [project_templates/cli-basic](project_templates/cli-basic)
+- [project_templates/ui-pyside6](project_templates/ui-pyside6)
+- Tests: [tests/test_template_cli_basic.py](tests/test_template_cli_basic.py), [tests/test_validate_templates.py](tests/test_validate_templates.py), [tests/test_pyproject_merge.py](tests/test_pyproject_merge.py)
+
+**Detaillierte TODOs pro Sub‑Issue (sequenziell ausführbar)**
+
+1) Sub‑Issue #29 — Quickstart: Von Scratch zum 'ready to use' Projekt
+- Ziel: konkreten Quickstart‑Guide erstellen und Beispielbefehle hinzufügen.
+- Schritte:
+  - Branch: `issue/5-29-quickstart` anlegen.
+  - Dateiänderungen: ergänze oder erstelle [docs/quickstart.md](docs/quickstart.md) (neue Datei) mit folgenden Abschnitten: Voraussetzungen, System‑Setup (poetry, node), `python -m pip install -e .`, Beispiel: `python -m template_python_projekt --template cli-basic --name demo` und erwartete Ausgabe/Ordnerstruktur.
+  - Ergänze kurze Verifizierung: Befehl, um Demo zu starten und Tests lokal laufen zu lassen.
+  - Lint/Test, Commit, Push, PR gegen `issue/5`, Merge.
+
+2) Sub‑Issue #30 — Detaillierte Anleitung: Nutzung des Starterskripts
+- Ziel: vollständige CLI‑Dokumentation.
+- Schritte:
+  - Branch: `issue/5-30-cli-docs`.
+  - Update [src/template_python_projekt/main.py] wenn Flags unvollständig dokumentiert sind (nur, falls nötig), ansonsten dokumentiere Flags in [docs/cli_spec.md] oder erweitere [docs/README.md].
+  - Füge Beispiel‑Usecases (z. B. `--template`, `--name`, `--force`, `--dry-run`) und erwartete Outcomes hinzu.
+  - Automatischer Test: erweitere oder verlinke `tests/test_template_cli_basic.py` mit minimaler CLI smoke test falls hilfreich.
+  - Lint/Test, Commit, Push, PR → Merge.
+
+3) Sub‑Issue #31 — Manuelle Initialisierung: Schritte ohne Starterskript
+- Ziel: Dokumentierte manuelle Schritte, die das Starter‑Skript reproduzieren.
+- Schritte:
+  - Branch: `issue/5-31-manual-init`.
+  - Dokument: `docs/manual_init.md` mit konkreten Kopiervorgängen, Merge‑Hinweisen (pyproject), und den wichtigsten Template‑Platzhaltern.
+  - Referenziere / verlinke `src/template_python_projekt/render.py` und `project_templates/common/pyproject.toml.jinja`.
+  - Ergänze Falls nötig Tests zu `test_pyproject_merge.py` mit einem zusätzlichen realistischen Merge‑Case.
+  - Lint/Test, Commit, Push, PR → Merge.
+
+4) Sub‑Issue #32 — Troubleshooting & FAQ
+- Ziel: FAQ mit Top‑10 Fehlern + fixes.
+- Schritte:
+  - Branch: `issue/5-32-troubleshooting`.
+  - Update [docs/README.md] oder neue `docs/faq.md` mit Abschnitten: `poetry missing`, `node missing`, `pre-commit fails`, `merge conflicts`, `permission errors`.
+  - Ergänze Code‑Snippets/Commands zum Beheben (z. B. `python -m pip install -e .`, `poetry install --with dev`, `pre-commit run --all-files`).
+  - Verlinke zu [src/template_python_projekt/node_env.py] und [src/template_python_projekt/poetry_env.py].
+  - Lint/Test, Commit, Push, PR → Merge.
+
+5) Sub‑Issue #33 — Contribution‑Guide
+- Ziel: `CONTRIBUTING.md` erstellen.
+- Schritte:
+  - Branch: `issue/5-33-contributing`.
+  - Erstelle `CONTRIBUTING.md` mit: Branch‑Naming, Commit‑Konvention, Test­anleitung, CI‑Checks, PR‑Checklist (siehe PR Vorlage oben), How‑to add templates (schema), und Pfade zu `project_templates/common/README.md.jinja`.
+  - Lint/Test, Commit, Push, PR → Merge.
+
+6) Sub‑Issue #34 — Beispielprojekte Dokumentation (CLI & PySide6)
+- Ziel: READMEs für `project_templates/cli-basic` und `project_templates/ui-pyside6`.
+- Schritte:
+  - Branch: `issue/5-34-examples-docs`.
+  - In `project_templates/cli-basic/docs/README.md.jinja` und `project_templates/ui-pyside6/docs/README.md.jinja` konkrete Run/Debug/Test/Packaging Schritte ergänzen.
+  - Für UI: Hinweise zu Headless/CI (oder markiere Demo als manuell).
+  - Lint/Test, Commit, Push, PR → Merge.
+
+7) Sub‑Issue #35 — Post‑Init Validierung: Checkliste & Automatische Prüfungen
+- Ziel: `scripts/check.sh` oder `Makefile` Target `check` erstellen, das folgende ausführt: `poetry install --with dev` (optional), `poetry run ruff check .`, `poetry run mypy .`, `pytest -q`, `pre-commit run --all-files`.
+- Schritte:
+  - Branch: `issue/5-35-postinit-check`.
+  - Erstelle `Makefile` oder `scripts/check.sh` (preferiere `scripts/check.sh` für Windows-kompatible PowerShell: `scripts/check.ps1` + `scripts/check.sh` für *nix). Implementiere und dokumentiere Verwendung.
+  - Ergänze `scripts/validate_templates.py` bzw. erweitere Tests in `tests/test_validate_templates.py` falls nötig.
+  - Lint/Test, Commit, Push, PR → Merge.
+
+8) Sub‑Issue #36 — Migration & Updates: Beste Praxis
+- Ziel: Migrations‑Guide und Beispiele für sichere Updates.
+- Schritte:
+  - Branch: `issue/5-36-migration-updates`.
+  - Dokument: `docs/migration.md` mit Schritt‑für‑Schritt, Beispiel‑pyproject Merge‑Flows, Hinweise zu `render.py` Merge‑Funktionen und Testcases.
+  - Ergänze Tests in `tests/test_pyproject_merge.py` für zusätzliche Fälle.
+  - Lint/Test, Commit, Push, PR → Merge.
+
+**Verification (End to End) nach allen Sub‑Issues**
+- Lokale: `poetry run ruff check .`, `poetry run mypy .`, `pytest -q` erfolgreich.
+- CI: `.github/workflows/ci.yml` grünes Ergebnis.
+- Dokumentation: `docs/README.md` enthält Links zu neuen `docs/*.md` Dateien.
+- Optional: ein CI Smoke job, der `python -m template_python_projekt --template cli-basic --name demo --target /tmp/demo` ausführt und anschließend die `scripts/check` aufruft.
+
+**Decisions / Annahmen**
+- PRs werden in `issue/5` gemerged, nicht direkt in `main`.
+- Merge‑Strategie: `Squash and merge` empfohlen für Sub‑Issue PRs.
+- Einzelperson Team → keine Reviewer nötig; PRs sollten dennoch die Checkliste enthalten.
+- Branches werden nur dann erstellt, wenn das Sub‑Issue aktuell bearbeitet wird.
+
+**Further Considerations**
+1. Möchtest du, dass ich die ersten Dateien (z. B. `docs/quickstart.md`, `CONTRIBUTING.md`, `scripts/check.ps1`) als Draft erstelle? Option A: Ja, erstelle die Dateien. Option B: Nein, nur Plan und then du implementierst.
+2. Soll ich zusätzlich CI‑Job‑Vorlage für Quickstart Smoke Test anlegen (separater PR nach #29/#35)?

--- a/.github/prompts/untitled-planIssue30.prompt.md
+++ b/.github/prompts/untitled-planIssue30.prompt.md
@@ -1,0 +1,174 @@
+## Plan: Sub-Issue 30 Umsetzung
+
+TL;DR - Was, warum, wie: Implementiere Sub‑Issue #30 auf Basis des Parent‑Branches `issue/5` in einem Sub‑Branch `issue/5-30-cli-docs`. Fokus: Änderungen an CLI‑Doku und zugehörigen Templates/Tests; lokale Verifikation durch `pytest`, `ruff` und `mypy`. PRs werden erst geöffnet wenn die Umsetzung komplett ist; kein Draft, deutscher Titel, ausführliche Beschreibung, Squash‑Merge.
+
+**Issue‑Details (Issue #30)**
+- **Titel:** Detaillierte Anleitung: Nutzung des Starterskripts (CLI Optionen & Beispiele)
+- **Akzeptanzkriterien:** Alle Flags dokumentiert mit Beispielen und Defaults.
+- **Estimate:** 4h
+- **Dependencies/Tags:** task-docs-usage
+- **Test‑Anweisungen:** Run documented examples and ensure outputs match.
+- **Labels:** documentation, task, priority:medium, area:docs
+- **Milestone:** Sprint 3
+- **Issue‑URL:** https://github.com/Eichi76/Template-Python-Projekt/issues/30
+
+**Steps**
+1. Issue‑Details holen (*abhängig von GitHub*):
+   - Hole Issue‑Text/Kommentare mit der `gh` CLI: `gh issue view 30 --repo Eichi76/Template-Python-Projekt --json title,body,comments`.
+   - Notiere Anforderungen, erwartete Dateien und Akzeptanzkriterien.
+2. Lokale Basis vorbereiten:
+   - Checkout Parent: `git fetch origin && git checkout issue/5 && git pull --ff-only`.
+   - Erstelle Sub‑Branch: `git checkout -b issue/5-30-cli-docs` (Branchname: `issue/5-30-cli-docs`).
+3. Analyse & Scope festlegen:
+   - Finde relevante Dateien (erste Empfehlung):
+     - `src/template_python_projekt/render.py` — Rendering‑Logik prüfen
+     - `src/template_python_projekt/main.py` — CLI‑Entry prüfen
+     - `project_templates/cli-basic/docs/index.md.jinja` — Doku‑Template
+     - `project_templates/cli-basic/src/main.py` — beispielhafte CLI‑Logik
+     - Tests: `tests/test_template_cli_basic.py`, `tests/test_render_directory.py`
+   - Ergänze die Liste wenn Issue‑Text zusätzliche Dateien nennt.
+4. Implementierung (iterativ, Commit‑granular):
+   - Kleine, in sich geschlossene Commits pro Änderung (Code, Tests, Templates, Docs).
+   - Bei jeder Änderung lokale Prüfungen ausführen (siehe Verifikation).
+5. Linting, Typechecking, Pre‑commit vor Push:
+   - Lint: `poetry run ruff check .` — alle Warnungen beheben.
+   - Typecheck: `poetry run mypy .` — Fehler/Warnungen beheben.
+   - Pre‑commit: `pre-commit run --all-files` — Hook‑Warnungen beheben.
+6. Tests ausführen:
+   - Relevante Tests lokal: `pytest -q tests/test_template_cli_basic.py tests/test_render_directory.py`.
+   - Falls neue Tests hinzugefügt: `pytest -q` gesamtes Testsuite.
+7. Commit‑Message & Push:
+   - Commit‑Message prägnant und Issue referenzierend: `git commit -m "issue/5-30: CLI‑Dokus erweitern — <kurze Beschreibung>"`.
+   - Push Branch: `git push --set-upstream origin issue/5-30-cli-docs`.
+8. Pull Request (erst wenn Issue fertig):
+   - Öffne PR gegen `issue/5`, kein Draft.
+   - PR‑Titel (Deutsch): z.B. "Issue 5‑30: CLI‑Dokumentation ergänzen und Templates anpassen".
+   - PR‑Beschreibung ausführlich: Hintergrund, gemachte Änderungen, geänderte Dateien, wie man lokal testet, Checkliste (Lints, Typchecks, Tests), evtl. Screenshots/Beispiele.
+   - Keine Reviewer (single‑person Team). Markiere ggf. CI/Checks als bestanden.
+9. Merge (nach Abnahme durch dich selbst):
+   - Verwende `Squash and merge` über GitHub UI.
+   - Merge‑Commit Nachricht: deutsche Zusammenfassung + Referenz auf Issue #30.
+10. Nacharbeiten:
+   - `git checkout issue/5 && git pull` und `git branch -d issue/5-30-cli-docs` lokal löschen.
+   - Falls nötig: Release/Changelog aktualisieren.
+
+**Relevant files**
+- `src/template_python_projekt/render.py` — Rendering‑Logik prüfen/erweitern
+- `src/template_python_projekt/main.py` — CLI‑Entry/Argumente
+- `project_templates/cli-basic/docs/index.md.jinja` — Doku‑Template anpassen
+- `project_templates/cli-basic/src/main.py` — CLI‑Beispielcode
+- `tests/test_template_cli_basic.py` — CLI‑Template Tests
+- `tests/test_render_directory.py` — Rendering Tests
+- `.github/prompts/plan-parentIssueFive.prompt.md` — Branch/Issue‑Konventionen referenzieren
+- `pyproject.toml` — Linter/Typecheck Konfiguration
+- `.pre-commit-config.yaml` — Pre‑commit Hooks
+
+**Verification**
+1. Lint & Typecheck: `poetry run ruff check .` → keine Warnungen; `poetry run mypy .` → keine Fehler.
+2. Pre‑commit Hooks: `pre-commit run --all-files` → alle Hooks erfolgreich.
+3. Tests: `pytest -q` → alle Tests grün; insbesondere `tests/test_template_cli_basic.py` und `tests/test_render_directory.py`.
+4. Manuelle Prüfung: Rendered docs prüfen (z. B. lokal generierte Dateien öffnen), CLI‑Beispiel durchlaufen.
+5. PR‑Verifikation: GitHub Checks (CI) grün, keine Lint/Type‑Failures in CI.
+
+**Decisions / Annahmen**
+- Branchname: `issue/5-30-cli-docs` (Nummer 30, kurzer beschreibender Suffix "cli-docs").
+- Basis-Branch: `issue/5` (nicht `main`).
+- Keine Draft‑PRs und keine Reviewer (Single‑Person Team).
+- Merge‑Strategie: `Squash and merge`.
+- GitHub Issue‑Details können via `gh` CLI oder MCP abgerufen werden (Token in Powershell env).
+
+**Further Considerations**
+1. Falls Issue‑Text weitere Dateien/Module nennt, erweitere Step 3 entsprechend.
+2. Wenn Änderungen am API‑Shape nötig sind, ergänze Typannotationen und erweitere Tests.
+3. Wenn CI zusätzliche Checks hat, führe diese lokal nach Möglichkeit aus (z. B. `isort`, `black` falls konfiguriert).
+
+**Detaillierte TODO‑Liste & Workflow (ausführlich)**
+
+1) Vorbereitung (10–15min)
+- Sicherstellen, dass lokales `issue/5` aktuell ist: `git fetch origin` -> `git checkout issue/5` -> `git pull --ff-only origin issue/5`.
+- Sub‑Branch erstellen (Konvention): `git checkout -b issue/5-30-cli-docs`.
+- Notiere Issue‑Akzeptanzkriterien lokal in einer kurzen TODO‑Datei (z. B. `docs/.issue-30-scope.md`).
+
+2) Discovery: gezielte Dateiuntersuchung (15–30min)
+- Prüfe `src/template_python_projekt/main.py` auf CLI‑Flags/Argumente.
+- Prüfe `src/template_python_projekt/render.py` auf Template‑Platzhalter, die Doku‑Ausgabe beeinflussen.
+- Öffne `project_templates/cli-basic/docs/index.md.jinja` und `project_templates/cli-basic/src/main.py` auf Beispiel‑Dokumentation und Beispiele.
+- Notiere fehlende Beispiele/Defaults und markiere Stellen zum Ergänzen.
+
+3) Änderungen planen (5–10min)
+- Lege feste Arbeitspakete (A–D):
+  A) Dokumentationstexte & Beispiele in `project_templates/cli-basic/docs/index.md.jinja` ergänzen.
+  B) Falls CLI‑Flags fehlen oder unklar sind: `src/template_python_projekt/main.py` kommentieren/ergänzen (help text, defaults).
+  C) Tests: Ergänze/aktualisiere `tests/test_template_cli_basic.py` mit Szenarien für dokumentierte Beispiele.
+  D) Render‑Verifikation: ggf. kleine Testfälle in `tests/test_render_directory.py` hinzufügen.
+
+4) Umsetzung (iterativ, je Arbeitspaket)
+- Für jedes Arbeitspaket:
+  - Erstelle lokalen Commit mit sinnvoller Message: `issue/5-30: [A] Kurze Beschreibung`.
+  - Führe Lint & Typecheck lokal: `poetry run ruff check .` und `poetry run mypy .` und behebe Warnungen.
+  - Führe relevante Tests aus: `pytest -q tests/test_template_cli_basic.py` (oder gesamte Suite wenn nötig).
+  - Pre‑commit Hooks prüfen: `pre-commit run --all-files`.
+  - Push: `git push --set-upstream origin issue/5-30-cli-docs` (erst nachdem mehrere Commits fertig sind oder am Ende der Arbeit).
+
+5) Tests & Verifikation (kontinuierlich)
+- Vor PR: Alle Tests lokal grün: `pytest -q`.
+- Lint/Typecheck sauber: `poetry run ruff check .` → 0 Warnungen; `poetry run mypy .` → 0 Fehler.
+- Pre‑commit Hooks ohne Fehler: `pre-commit run --all-files`.
+- Manuelle Ausführung der dokumentierten Beispiele: Starterskript mit dokumentierten Flags laufen lassen und Ausgabe vergleichen (siehe Issue „Test Commands"). Notiere Ergebnisse in `docs/.issue-30-test-results.md`.
+
+6) PR‑Vorbereitung (abschließend)
+- PR öffnen erst wenn alle Tasks abgeschlossen.
+- PR‑Branch: `issue/5-30-cli-docs` → Target: `issue/5`.
+- PR‑Titel (Deutsch, Beispiel): `Issue 5‑30: Detaillierte Anleitung zur Nutzung des Starterskripts (CLI‑Optionen & Beispiele)`.
+- PR‑Beschreibung (ausführlich; Punkte):
+  - Kurzbeschreibung & Hintergrund.
+  - Erfüllte Akzeptanzkriterien (Liste, Häkchen für abgeschlossen).
+  - Änderungen (Dateiliste mit Pfaden).
+  - Wie lokal testen (Kurzbefehle & erwartete Ausgaben).
+  - Lint/Typecheck/Tests Status (ergebnisbasiert).
+  - Hinweise für Maintainer (falls relevant).
+- Merge‑Strategie: `Squash and merge` über GitHub UI.
+
+7) Commit‑/Branch‑Konventionen
+- Branchname: `issue/5-30-cli-docs`.
+- Commit‑Prefix: `issue/5-30:` gefolgt von kurzen deutschen Beschreibungen.
+- Keine Draft‑PRs; PRs erst bei kompletter Umsetzung.
+
+8) Post‑Merge
+- Lokal: `git checkout issue/5 && git pull`.
+- Optional: `git branch -d issue/5-30-cli-docs`.
+- Aktualisiere ggf. `CHANGELOG.md` oder `docs/README.md` falls Dokumentation eine sichtbare Änderung für Nutzer darstellt.
+
+**Konkrete Dateiaufgaben (checkbare ToDos)**n- [ ] A. `project_templates/cli-basic/docs/index.md.jinja`: Für jedes CLI‑Flag: Beschreibung, Default, Beispielaufruf, erwartete Ausgabe.
+- [ ] B. `src/template_python_projekt/main.py`: Kanalisiere oder erweitere `--help`/Docstrings falls notwendig.
+- [ ] C. `src/template_python_projekt/render.py`: Sicherstellen, dass die Doku‑Platzhalter korrekt gerendert werden (z. B. Defaults eingefügt).
+- [ ] D. `tests/test_template_cli_basic.py`: Neue Tests für die dokumentierten Beispiele hinzufügen (Mocks/fixtures verwenden falls nötig).
+- [ ] E. `tests/test_render_directory.py`: Falls Rendering‑Änderungen, ergänzende Tests.
+- [ ] F. Dokumentations‑Artefakte: `docs/.issue-30-scope.md`, `docs/.issue-30-test-results.md`.
+
+**PR‑Beschreibung Vorlage (Deutsch, kopierbar)**
+Titel: Issue 5‑30: Detaillierte Anleitung zur Nutzung des Starterskripts (CLI‑Optionen & Beispiele)
+
+Beschreibung:
+- Zusammenfassung: Erweiterte Dokumentation des Starterskripts, Beschreibungen aller CLI‑Flags, Defaults und Anwendungsbeispiele.
+- Erfüllte Akzeptanzkriterien:
+  - [x] Alle Flags dokumentiert
+  - [x] Beispiele mit erwarteter Ausgabe
+- Änderungen (kurz):
+  - `project_templates/cli-basic/docs/index.md.jinja` — Ergänzte Flag‑Beschreibungen und Beispiele
+  - `tests/test_template_cli_basic.py` — Neue Tests für Beispiele
+- Lokales Testen:
+  - `poetry run pytest -q tests/test_template_cli_basic.py`
+  - `poetry run ruff check .` und `poetry run mypy .`
+  - Manuelle Ausführung: `python -m template_python_projekt --help` (oder `python -m template_python_projekt.cli` je nach Entry)
+- Hinweise:
+  - Single‑person Team: keine Reviewer nötig.
+  - Merge: Squash‑Merge.
+
+**Risiken & Mitigations**
+- Risiko: Unklare Flags in Code → Prüfung: `main.py` und Unit‑Tests erweitern.
+- Risiko: Template‑Placeholder fehlen → Anpassung in `render.py` und Ergänzung von Integrations‑Tests.
+- Mitigation: Kleine, verifizierbare Commits + Tests pro Änderungspaket.
+
+**Zeitschätzung**
+- Total: ~4h (Issue Estimate) verteilt auf: Discovery 30min, Implementierung 2–2.5h, Tests/PR 30–60min.

--- a/.github/prompts/untitled-planManualInitialization.prompt.md
+++ b/.github/prompts/untitled-planManualInitialization.prompt.md
@@ -1,0 +1,69 @@
+## Plan: Manual Init für Issue #31
+
+TL;DR - Was / Warum / Wie:
+Erstelle eine nachvollziehbare, manuelle Anleitung, die das Verhalten des Starterskripts reproduziert (Issue #31). Vorgehen: Sub-Branch vom Parent `issue/5` anlegen, Dokumentation hinzufügen/ändern, Tests prüfen/aktualisieren, Linting/Typing/Pre-commit ausführen, Änderungen committen und am Ende einen PR mit deutschem Titel und ausführlicher Beschreibung öffnen und per Squash-Merge zusammenführen.
+
+**Steps**
+1. Branch erstellen (lokal):
+   - Auschecken von `issue/5` und neuen Sub‑Branch anlegen: `issue/5-31-manual-init` (Benennung folgt `issue/5-<num>-<short>`). *depends on: aktueller Branch `issue/5` lokal vorhanden*
+2. Issue‑Details sichern:
+   - Hole den vollständigen Issue‑Text, Akzeptanzkriterien und Kommentare mit `gh issue view 31 --repo Eichi76/Template-Python-Projekt --json body,comments,labels` oder via MCP‑Tools; füge einen Link/Referenz in die neue Dokumentation und in den Commit‑Message/PR‑Beschreibung ein. *parallel mit Step 1*
+3. Zielumfang festlegen (Dokumentstruktur):
+   - Erstelle neue Datei `docs/manual_initialization.md` als konkrete Empfehlung, oder erweitere [docs/quickstart.md](docs/quickstart.md) / [docs/README.md](docs/README.md) falls Integration bevorzugt wird. Entscheide eine Option zu Beginn.
+4. Implementierung der Dokumentation:
+   - Beschreibe Schritt‑für‑Schritt die manuelle Reproduktion der Starter‑Skript‑Ausgabe: erwartete Ordner/Dateien, pyproject‑Merges, pre-commit, virtuelle Umgebung, typische Befehle.
+   - Ziehe Referenzen aus [project_templates/cli-basic/docs/README.md](project_templates/cli-basic/docs/README.md) und [project_templates/cli-basic/src/main.py](project_templates/cli-basic/src/main.py) heran.
+5. Tests prüfen und ggf. anpassen:
+   - Führe relevante Tests lokal: `poetry run pytest -q tests/test_template_cli_basic.py tests/test_render_directory.py tests/test_docs_render.py`.
+   - Falls Tests fehl schlagen, ergänze Tests oder passe Beispiel‑Outputs in `project_templates` an. *depends on Step 4*
+6. Lint/Type/Pre-commit Durchlauf und Fixes:
+   - `poetry run ruff check .` → alle Warnungen/Bugs beheben.
+   - `poetry run mypy .` → Typfehler beheben (beachte mypy Einstellungen in `pyproject.toml`).
+   - `pre-commit` Hooks ausführen und Issues ausgleichen (`poetry run pre-commit run --all-files` oder lokal `pre-commit run --all-files`).
+   - Wiederhole bis lints/typing/Pre-commit grün sind.
+7. Commits & Commit‑Strategie:
+   - Kleine, thematisch geordnete Commits (z. B. `docs: add manual initialization guide`, `tests: add manual init checks`, `fix: ruff/mypy issues`).
+   - Nutze aussagekräftige Commit‑Messages; referenziere Issue `#31` in der Nachricht.
+8. Push & PR‑Vorbereitung:
+   - Push den Branch: `git push -u origin issue/5-31-manual-init`.
+   - Erstelle PR erst wenn alle Tasks abgeschlossen. PR darf kein Draft sein.
+   - PR‑Titel auf Deutsch, z. B.: "Dokumentation: Manuelle Initialisierung reproduzierbar machen (Issue #31)"
+   - PR‑Beschreibung: ausführliche Schritte, betroffene Dateien (Liste), Testanweisungen, Akzeptanzkriterien aus Issue #31, und Hinweis auf `poetry run ruff check .`, `poetry run mypy .`, `poetry run pytest -q` als Verifikation.
+9. Merge:
+   - Nach Abnahme per Squash‑Merge mergen.
+   - Keine weiteren Reviewer nötig (Single‑Person Team) – setze Reviewer optional auf dich selbst.
+10. Nacharbeiten:
+   - Entferne temporäre Debug‑Änderungen.
+   - Ergänze `CHANGELOG.md` falls nötig.
+
+**Relevant files**
+- [docs/manual_initialization.md](docs/manual_initialization.md) — neue empfohlene Datei (oder alternativ: Erweiterung von [docs/quickstart.md](docs/quickstart.md)).
+- [docs/quickstart.md](docs/quickstart.md) — mögliche Integrationsstelle.
+- [docs/README.md](docs/README.md) — übergeordnete Doku‑Referenz.
+- [project_templates/cli-basic/docs/README.md](project_templates/cli-basic/docs/README.md) — Template‑Beispiele nutzen.
+- [project_templates/cli-basic/src/main.py](project_templates/cli-basic/src/main.py) — Beispielverhalten des Starterskripts.
+- [src/template_python_projekt/render.py](src/template_python_projekt/render.py) — relevante Logik/Referenz.
+- Tests:
+  - [tests/test_template_cli_basic.py](tests/test_template_cli_basic.py)
+  - [tests/test_render_directory.py](tests/test_render_directory.py)
+  - [tests/test_docs_render.py](tests/test_docs_render.py)
+
+**Verification**
+1. Lint/Type/Pre-commit: `poetry run ruff check .`, `poetry run mypy .`, `poetry run pre-commit run --all-files` → keine Warnungen/Fehler.
+2. Tests: `poetry run pytest -q --maxfail=1` → alle relevanten Tests grün.
+3. Manuelle Prüfung: In einer frischen Umgebung (neues venv) die Schritte aus `docs/manual_initialization.md` durchführen und vergleichen mit Ergebnissen des Starterskripts (Dateien/Ordner/pyproject‑Merges).
+4. PR‑Beschreibung enthält Link auf Issue #31 und eine Checkliste der erledigten Acceptance Criteria.
+
+**Decisions / Annahmen**
+- Die Anleitung wird als `docs/manual_initialization.md` neu angelegt, sofern nichts anderes gewünscht ist.
+- Branchname: `issue/5-31-manual-init` (konform zu `issue/5-<num>-<short>`).
+- PR wird nicht als Draft erstellt; Merge per Squash sobald alles erledigt ist.
+- Keine weiteren Reviewer nötig (Single‑Person Team).
+
+**Further Considerations / Offene Fragen**
+1. Bevorzugst du eine neue Doku‑Datei (`docs/manual_initialization.md`) oder eine Integration in bestehende `docs/quickstart.md`? Empfehlung: neue Datei für bessere Auffindbarkeit.
+2. Sollen im Zuge der Dokumentation Beispiel‑Änderungen in `project_templates` (z. B. zusätzliche README‑Beispiele) vorgenommen werden, oder beschränken wir uns nur auf Dokumentation?
+3. Möchtest du, dass ich per `gh` CLI den Issue 31 vollständig downloade / verlinke und den Branch lokal anlege/pushe (benötigt Terminalzugriff und konfiguriertes `gh`/Token)?
+
+---
+Plan erstellt auf Basis der Repo‑Analyse und der Issue‑Meta‑Daten. Wenn du bestätigst, passe ich den Plan an (z.B. Dateinamen oder PR‑Titel) oder starte die Umsetzungsschritte (Branch anlegen, Dateien erzeugen, Änderungen lokal testen).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Alle signifikanten Änderungen am Projekt werden hier dokumentiert.
   Beispielen und erwarteter Ausgabe; ergänzender Dry‑Run‑Test
   `tests/test_template_cli_basic.py::test_example_dry_run` (Issue #30, PR #64).
 
+- Dokumentation für Beispielprojekte: `cli-basic` und `ui-pyside6` —
+  neue `README.md.jinja` Templates mit Anleitungen zum Ausführen,
+  Debuggen, Testen und Packaging sowie Beispielausgaben (Issue #34, PR #70).
+
 ### Changed (Unreleased)
 
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Alle signifikanten Änderungen am Projekt werden hier dokumentiert.
 
 - Platz für laufende Änderungen bis zum nächsten Release.
 
+- Detaillierte Anleitung: Nutzung des Starterskripts
+  (`--template`, `--name`, `--dest`, `--dry-run`, `--force`) mit
+  Beispielen und erwarteter Ausgabe; ergänzender Dry‑Run‑Test
+  `tests/test_template_cli_basic.py::test_example_dry_run` (Issue #30, PR #64).
+
 ### Changed (Unreleased)
 
 -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contribution Guide
+
+Dieses Dokument beschreibt, wie Beiträge zu diesem Repository eingereicht,
+getestet und gemerged werden sollen. Ziel ist ein reproduzierbarer Prozess
+für neue Templates und Anpassungen an bestehenden Templates.
+
+## Kurzer Workflow
+
+- Basis‑Branch für Feature‑Arbeit: `issue/5` (Sub‑Branches im Format
+  `issue/5-<num>-<short>`).
+- Erstelle lokalen Branch, implementiere Änderungen, sorge dafür, dass alle
+  Checks grün sind und öffne erst dann einen Pull Request gegen `issue/5`.
+- PR‑Titel auf Deutsch, Merge per Squash‑Merge.
+- Single‑Person‑Team: keine weiteren Reviewer nötig.
+
+## Branching
+
+- Hole zuerst den aktuellen Parent‑Branch:
+
+```powershell
+git fetch
+git checkout issue/5
+git pull --ff-only origin issue/5
+git checkout -b issue/5-33-contrib-guide
+```
+
+Ersetze `33` und `contrib-guide` entsprechend Issue‑Nummer und kurzer
+Beschreibung.
+
+## Tests & lokale Checks
+
+Führe vor Commits und Pushs stets die folgenden Befehle aus:
+
+```powershell
+# Lint
+poetry run ruff check .
+
+# Typechecking
+poetry run mypy .
+
+# Pre-commit Hooks (lokal)
+pre-commit run --all-files
+
+# Tests
+pytest -q --cov=src --cov-report=xml
+```
+
+Wenn ein Check fehlschlägt, behebe die Fehler lokal und wiederhole die
+Befehle. Commits sollten die Hooks passieren (pre-commit ist konfiguriert).
+
+## Template‑Metadata‑Schema (Empfehlung)
+
+Neue oder geänderte Templates sollten eine kurze Metadaten‑Sektion (YAML)
+enthalten, die vom Renderer erwartet wird. Beispiel (`template.yaml`):
+
+```yaml
+name: "cli-basic"
+version: "0.1.0"
+description: "Minimal template für CLI‑Projekte"
+author: "Your Name <mail@example.com>"
+tags:
+  - cli
+  - basic
+compatibility:
+  python: ">=3.12,<3.13"
+tests:
+  - "pytest"
+```
+
+Dokumentiere alle erforderlichen Metafelder in der jeweiligen
+Template‑README.
+
+## PR‑Checklist (für die Beschreibung)
+
+Eine PR Beschreibung muss mindestens enthalten:
+
+- Deutschen Titel, z. B. „Issue 33: Contribution‑Guide für Templates
+  hinzufügen“
+- Kurze Zusammenfassung der Änderungen
+- Motivation / Problem, das gelöst wird
+- Akzeptanzkriterien (siehe Issue #33)
+- Liste der ausgeführten Checks (ruff, mypy, pre-commit, pytest) und deren
+  Status
+- Hinweise zur manuellen Verifikation (Schritte, Dateien zu prüfen)
+- Falls relevant: Migrationsschritte, Breaking Changes, Follow‑ups
+
+Beispiel `gh`‑Befehl zum Erstellen des PRs (erst ausführen, wenn alles grün
+ist):
+
+```powershell
+gh pr create --base issue/5 --title "Issue 33: Contribution‑Guide für
+Templates hinzufügen" --body "<ausführliche Beschreibung>" --repo
+Eichi76/Template-Python-Projekt
+```
+
+## Commit‑Konventionen
+
+- Schreibe klare Commit‑Nachrichten; gruppiere Änderungen thematisch.
+- Pre‑commit Hooks laufen beim Commit; falls Hooks Fehler melden, behebe
+  diese vor Push.
+
+## Verantwortlichkeit & Review
+
+- Da dieses Repo als Single‑Person‑Team geführt wird, genügt die eigene
+  Prüfung; PRs werden nach eigener Abnahme per Squash‑Merge zusammengeführt.
+
+## Fragen
+
+Bei Rückfragen oder Unklarheiten verweise auf Issue #33 oder öffne ein
+kurzes Issue/PR‑Kommentar.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: check check-unix check-windows
+
+check: check-unix
+
+check-unix:
+	@echo "Running make check (Unix shell)"
+	poetry env check
+	poetry run pytest -q
+	pre-commit run --all-files
+	@if [ -f package.json ]; then \
+		echo "Found package.json — running npm run lint:md"; \
+		npm run lint:md || true; \
+	else \
+		echo "No package.json found — skipping npm lint"; \
+	fi
+
+check-windows:
+	@echo "Running make check (PowerShell)"
+	powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/check.ps1

--- a/docs/.issue-30-scope.md
+++ b/docs/.issue-30-scope.md
@@ -1,0 +1,16 @@
+# Scope Issue #30 — CLI‑Dokumentation
+
+## Ziel
+
+- Alle CLI‑Flags des Starter‑Skripts dokumentieren.
+- Beispiele mit erwarteter Ausgabe bereitstellen.
+
+## Akzeptanzkriterien
+
+- [ ] Alle Flags dokumentiert
+- [ ] Beispiele erzeugen die dokumentierte Ausgabe (manuell geprüft)
+
+## Notizen
+
+- Basis‑Branch: issue/5
+- Sub‑Branch: issue/5-30-cli-docs

--- a/docs/.issue-30-test-results.md
+++ b/docs/.issue-30-test-results.md
@@ -1,0 +1,18 @@
+# Test‑Ergebnisse (manuell)
+
+## Beispiel: Dry‑Run
+
+### Befehl
+
+```bash
+python -m template_python_projekt --template cli-basic --name demo --dry-run
+```
+
+### Erwartet (Beispiel)
+
+- `starter: template=cli-basic, name=demo, dest=., dry_run=True, force=False`
+- `Would write:` Zeilen mit den geplanten Zieldateien
+
+### Tatsächlich
+
+- (Hier nach Ausführung ergänzen)

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,9 @@ gehalten, dass lokale `poetry run` Befehle sie reproduzieren.
 - Ruff/Mypy Fehler: `poetry run ruff check .` und `poetry run mypy .` lokal
   ausführen und Fehler beheben.
 
+Weitere Details und eine ausführliche FAQ findest du in
+[Troubleshooting & FAQ](troubleshooting.md).
+
 ## Contributing
 
 - Branch‑Naming: `issue/4-<num>-<short>` (Sub‑Issue Branches gegen `issue/4`).

--- a/docs/manual_initialization.md
+++ b/docs/manual_initialization.md
@@ -1,0 +1,92 @@
+# Manuelle Initialisierung — Reproduzieren des Starterskripts (Issue #31)
+
+Zweck
+
+- Beschreibt die Schritte, mit denen das Verhalten des Starterskripts
+  `template_python_projekt` nachvollzogen werden kann.
+
+Akzeptanzkriterien
+
+- Ein Nutzer kann die Ausgabe und die Struktur reproduzieren, die das
+  Starterskript erzeugt.
+- Alle in den Templates erzeugten Dateien und Merge‑Schritte sind
+  dokumentiert.
+- Die Anleitung ist in einer frischen Umgebung ausführbar.
+
+Voraussetzungen
+
+- `python >=3.12` installiert
+- `poetry` oder `python -m pip` zur lokalen Installation
+- Git und ein frisches Arbeitsverzeichnis für den Test
+
+Kurzanleitung (Beispielablauf)
+
+1. Repository klonen
+
+```bash
+git clone https://github.com/Eichi76/Template-Python-Projekt.git
+cd Template-Python-Projekt
+```
+
+1. Installieren (empfohlen: Poetry)
+
+```bash
+poetry install --with dev
+# oder: python -m pip install -e .
+```
+
+1. Virtuelle Umgebung aktivieren (falls nicht durch Poetry verwaltet)
+
+1. Starterskript ausführen (Beispiel)
+
+```bash
+python -m template_python_projekt --template cli-basic \
+  --output /pfad/zum/zielprojekt
+```
+
+1. Erwartete Ausgabe / Struktur prüfen
+
+- `pyproject.toml` im Zielprojekt vorhanden und zusammengeführte
+  Einstellungen enthalten
+- Ordnerstruktur: `src/`, `model/`, `view/`, `controller/` wie in den
+  `project_templates/*` Vorlagen
+- `README.md` und `pre-commit-config.yaml` (falls das Template sie
+  enthält) vorhanden
+
+1. Manuelle Reproduktionsschritte (was das Starterskript intern macht)
+
+- Kopiere Dateien und Templates aus
+  `project_templates/<template>/src/` nach dem Zielprojekt
+- Führe die Merge‑Logik für `pyproject.toml` aus (ggf. nur bestimmte
+  Felder)
+- Kopiere die `pre-commit` Konfiguration und installiere lokale Hooks
+
+Empfohlene Befehle zur Verifikation
+
+```bash
+# Linting
+poetry run ruff check .
+# Type checks
+poetry run mypy .
+# Tests
+poetry run pytest -q tests/test_template_cli_basic.py
+```
+
+Häufige Prüfpunkte / Troubleshooting
+
+- Fehlende Abhängigkeiten: `poetry install` erneut ausführen
+- Merge‑Konflikte in `pyproject.toml`: prüfen, welche Felder vom
+  Template erwartet werden
+- Line‑Endings / Rechte: sicherstellen, dass `pre-commit` installiert
+  ist
+
+Weiteres
+
+- Ergänze hier Beispiele für spezifische Template‑Outputs, falls du
+  konkrete Vergleichsoutputs (z. B. vollständiges `pyproject.toml`) wünschst.
+
+Referenzen
+
+- `project_templates/cli-basic/`
+- `src/template_python_projekt/render.py`
+- Issue: [#31](https://github.com/Eichi76/Template-Python-Projekt/issues/31)

--- a/docs/migration_and_updates.md
+++ b/docs/migration_and_updates.md
@@ -1,0 +1,142 @@
+# Migration & Updates — Beste Praxis
+
+Diese Seite bietet eine Checkliste und sichere Vorgehensweisen zum
+Aktualisieren bestehender Projekte, basierend auf Issue #36.
+
+## Kurzüberblick
+
+- Ziel: sichere, reproduzierbare Updates von Projekten, inklusive Backup- und
+  Test-Schritten.
+
+## Schnell-Checkliste
+
+1. Vollständiges Backup / Git-Branch erstellen
+1. Abhängigkeiten prüfen (`poetry show --outdated`)
+1. Tests lokal laufen lassen (`poetry run pytest -q`)
+1. Änderungen in temporäre Dateien rendern
+1. Dateien vergleichen und Konflikte manuell lösen
+1. Commit, Lint & Typecheck
+1. Merge nach erfolgreicher QA
+
+## Beispiele
+
+(Platzhalter — konkrete Beispiele zu `pyproject.toml` und `README.md`
+folgen in einem späteren Commit)
+
+## Troubleshooting
+
+(Platzhalter)
+
+---
+
+*Scaffold erstellt für Issue #36 — weitere Inhalte folgen.*
+
+## Detaillierte Schritt-für-Schritt Anleitung
+
+1. Vorbereitung
+
+- Erstelle einen neuen Branch vom aktuellen Arbeitsbranch, z. B.:
+
+  ```bash
+  git checkout -b issue/5-36-migration issue/5
+  ```
+
+- Erstelle ein vollständiges Backup oder stelle sicher, dass alle
+  Änderungen versioniert sind.
+
+1. Abhängigkeiten prüfen
+
+- Prüfe veraltete Abhängigkeiten:
+
+  ```bash
+  poetry show --outdated
+  ```
+
+1. Tests vorab laufen lassen
+
+- Führe die Tests lokal über Poetry aus:
+
+  ```bash
+  poetry run pytest -q
+  ```
+
+- Behebe Fehler bevor du Änderungen an der Zielstruktur anwendest.
+
+1. Dry Run / Render in temporäre Dateien
+
+- Render die Templates in ein temporäres Verzeichnis, statt direkt zu
+  überschreiben. Vergleiche die gerenderten Dateien mit den existierenden
+  Dateien (diff).
+
+1. Dateien vergleichen und Konflikte lösen
+
+- Nutze `git diff`, `diff`-Tools oder `meld`/`kdiff3` um Änderungen zu prüfen.
+
+1. Änderungen anwenden (Update-Strategien)
+
+- Standard-Verhalten: `backup` — die bestehende Datei wird als
+  `filename.bak.TIMESTAMP` gesichert und die neue Datei geschrieben.
+- Alternativen: `skip` (bestehende Datei behalten) oder `overwrite` (direkt ersetzen).
+
+- Beispiel-CLI (Später implementiert in `template_python_projekt`):
+
+  ```bash
+  python -m template_python_projekt \
+    --update-mode backup \
+    --render target_dir
+  ```
+
+1. Lint, Typecheck und Pre-commit
+
+- Linting mit Ruff:
+
+  ```bash
+  poetry run ruff check .
+  ```
+
+- Typechecking mit mypy:
+
+  ```bash
+  poetry run mypy .
+  ```
+
+- Führe `pre-commit run --all-files` falls gewünscht aus und behebe Hinweise.
+
+1. Commit & QA
+
+- Committe die Änderungen in sinnvollen Schritten (Docs, Templates, Code, Tests).
+- Führe die Tests erneut aus und verifiziere das Verhalten:
+
+  ```bash
+  poetry run pytest -q
+  ```
+
+1. Pull Request
+
+- Erstelle den PR mit deutschem Titel, ausführlicher Beschreibung und How‑to‑Test.
+- Merge per `squash` nach erfolgreicher QA.
+
+## Konkrete Beispiele
+
+### Beispiel: `pyproject.toml` update
+
+1. Render die neue `pyproject.toml` in ein temporäres Verzeichnis.
+1. Vergleiche die Abschnitte `tool.poetry.dependencies` und `tool.poetry.dev-dependencies`.
+1. Übernimm nur notwendige Änderungen manuell oder per Patch.
+
+### Beispiel: `README.md` Merge‑Muster
+
+- Bewahre Projekt-spezifische Abschnitte (z. B. Usage, Beispiele) und
+  übernehme generische Vorlagen-Änderungen.
+
+## Troubleshooting — Häufige Probleme
+
+- Markdownlint/Formatting-Fehler: `pre-commit` ausführen und Hinweise befolgen.
+- Fehlende Type-Hinweise: mypy-Fehler lesen und schrittweise beheben.
+- Merge-Konflikte: lieber manuell lösen, Backup-Dateien nutzen.
+
+## Hinweise zur CLI-Integration
+
+- Flag-Name: `--update-mode` (Werte: `backup`, `skip`, `overwrite`).
+- Default: `backup`.
+- Die CLI ist nicht-interaktiv; automatische Entscheidungen werden dokumentiert.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart — Von Scratch zum "ready to use" Projekt
+
+Dieses Quickstart beschreibt in wenigen Schritten, wie ein neues Projekt aus
+den Vorlagen erzeugt und lokal verifiziert wird.
+
+Voraussetzungen
+
+- Python 3.12
+- `poetry` (empfohlen) oder `pip` für Entwicklungsinstallation
+- Optional: `node`/`npm` für Templates, die JS/MD‑Tools nutzen
+
+Schritte
+
+1. Repository klonen
+
+```bash
+git clone https://github.com/Eichi76/Template-Python-Projekt.git
+cd Template-Python-Projekt
+```
+
+1. Parent‑Branch auschecken (optional, für Issue‑Workflows)
+
+```bash
+git checkout issue/5
+```
+
+1. Paket für Entwicklung installieren
+
+Mit Poetry:
+
+```bash
+poetry install --with dev
+```
+
+Alternativ (pip editable):
+
+```bash
+python -m pip install -e .
+```
+
+1. Projekt aus Template erzeugen (Beispiel: CLI‑Template)
+
+```bash
+python -m template_python_projekt --template cli-basic --name demo
+```
+
+Erwartetes Ergebnis:
+
+Ein neues Verzeichnis `demo/` mit der typischen MVC‑Struktur
+(`model/`, `view/`, `controller/`). Zusätzlich werden eine
+`pyproject.toml` und eine Beispiel‑`README.md` erzeugt.
+
+1. Verifizieren
+
+- Linting:
+
+```bash
+poetry run ruff check .
+```
+
+- Typecheck:
+
+```bash
+poetry run mypy .
+```
+
+- Tests (im Projekt‑Root):
+
+```bash
+pytest -q
+```
+
+Häufige Probleme
+
+- `poetry` fehlt: siehe `docs/README.md` (Troubleshooting).
+- Schreibrechte: Stelle sicher, dass das Zielverzeichnis beschreibbar ist.
+
+Nächste Schritte
+
+- Ergänze diesen Quickstart mit Screenshots, Beispielausgaben und
+  optionalen CI‑Skripten zum Smoke‑Test.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,3 +79,7 @@ Nächste Schritte
 
 - Ergänze diesen Quickstart mit Screenshots, Beispielausgaben und
   optionalen CI‑Skripten zum Smoke‑Test.
+
+- Siehe auch die detaillierte Anleitung zur manuellen Initialisierung:
+  [Manuelle Initialisierung](manual_initialization.md) — reproduziert das
+  Verhalten des Starterskripts Schritt für Schritt (Issue #31).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,134 @@
+# Troubleshooting & FAQ
+
+Dieses Dokument fasst die häufigsten Probleme beim Arbeiten mit dem
+Template‑Projekt zusammen und bietet kurze Lösungshinweise.
+
+Kurz: Wenn ein Werkzeug fehlt oder ein Hook scheitert, reproduziere das
+Problem lokal und folge den in dieser Datei beschriebenen Schritten.
+
+## Top-10 Fehlerfälle
+
+### 1) `poetry` fehlt / `poetry` nicht gefunden
+
+Symptom: `poetry`-Befehle schlagen fehl.
+
+Ursache: Poetry ist nicht installiert oder nicht im PATH.
+
+Lösung:
+
+- `python -m pip install --user poetry`
+- `poetry --version`
+
+### 2) `node` fehlt
+
+Symptom: Node‑abhängige Tools melden `node: command not found`.
+
+Ursache: Node ist nicht installiert oder veraltet.
+
+Lösung:
+
+- Installiere Node (LTS), z. B. [Node.js](https://nodejs.org)
+- `node --version`
+
+### 3) `pre-commit` schlägt fehl
+
+Symptom: Hooks verhindern Commits oder melden Fehler.
+
+Ursache: Style/Format oder fehlende Tools.
+
+Lösung:
+
+- `pre-commit run --all-files`
+- Falls Hooks automatisch fixen, `git add` und erneut prüfen.
+
+### 4) Merge‑Konflikte
+
+Symptom: `git merge`/PR zeigt Konflikte.
+
+Ursache: Änderungen an denselben Zeilen in mehreren Branches.
+
+Lösung:
+
+- `git fetch origin` && `git rebase origin/main`
+- Konflikte manuell lösen, testen und committen.
+
+### 5) Dateiberechtigungen / Schreibschutz
+
+Symptom: Schreibfehler beim Erstellen oder Ändern von Dateien.
+
+Ursache: Fehlende Dateirechte oder schreibgeschützte Ordner.
+
+Lösung:
+
+- Prüfe Dateirechte; passe Rechte an oder nutze erhöhte Rechte.
+
+### 6) virtuelle Umgebung / falsche Python-Version
+
+Symptom: mypy/pytest/ruff melden Inkompatibilitäten.
+
+Ursache: Falsche Python‑Version oder aktive Umgebung.
+
+Lösung:
+
+- `python -m venv .venv` und aktivieren
+- `poetry install --with dev` oder `pip install -e .`
+
+### 7) `pyproject.toml` Merge-/Formatprobleme
+
+Symptom: TOML‑Blöcke kollidieren nach Merge.
+
+Ursache: Manuelle Änderungen in verschiedenen Branches.
+
+Lösung:
+
+- Vergleiche mit Tools oder `tomllib`, teste `poetry lock` danach.
+
+### 8) Template Rendering Fehler
+
+Symptom: Gerenderte Dateien enthalten Platzhalter oder fehlen Werte.
+
+Ursache: Fehlende Variablen oder Jinja‑Syntaxfehler.
+
+Lösung:
+
+- Renderer lokal testen, z. B.:
+
+  ```bash
+  python -c "from template_python_projekt import render; \
+  print(render.render_template_file('path', {'name':'x'}))"
+  ```
+
+### 9) Fehlende Templates / falscher Name
+
+Symptom: `FileNotFoundError: Template not found` beim Rendern.
+
+Ursache: Template fehlt oder falscher Pfad/Name.
+
+Lösung:
+
+- Prüfe `project_templates/<name>/src` und nutze den korrekten Namen.
+
+### 10) CI‑Fehler nach Push
+
+Symptom: GitHub Actions fehlschlagen (Tests/Lint).
+
+Ursache: Unterschiede zwischen lokaler Umgebung und CI.
+
+Lösung:
+
+- Reproduziere CI‑Schritte lokal: `poetry run ruff check .` und `pytest -q`.
+
+## Debugging‑Tipps
+
+- Zuerst lokal reproduzieren: `ruff`, `mypy`, `pytest`.
+- Nutze `--verbose` für mehr Logs.
+
+## Nützliche Befehle
+
+- `poetry install --with dev`
+- `pre-commit run --all-files`
+- `pytest -q --cov=src --cov-report=xml`
+
+## Weiterführende Links
+
+- README.md und `docs/README.md` für Template‑Konventionen.

--- a/project_templates/cli-basic/docs/README.md.jinja
+++ b/project_templates/cli-basic/docs/README.md.jinja
@@ -1,0 +1,83 @@
+# {{ project_name }} — Beispiel: CLI Basic
+
+Diese Datei beschreibt, wie man das generierte CLI‑Beispielprojekt ausführt, debuggt, testet und paketiert. Die Schritte sind so formuliert, dass sie direkt aus dem gerenderten Template anwendbar sind.
+
+## Schnellstart — Ausführen
+
+1) Projekt generieren (Dry‑Run)
+
+```bash
+python -m template_python_projekt --template cli-basic --name demo --dry-run
+```
+
+2) Projekt wirklich erzeugen
+
+```bash
+python -m template_python_projekt --template cli-basic --name demo
+cd demo
+```
+
+3) CLI ausführen
+
+```bash
+python -m demo.main --help
+```
+
+Erwartete Ausgabe (Beispiel):
+
+```
+usage: main.py [-h] [--example EXAMPLE]
+
+Demo CLI
+optional arguments:
+  -h, --help       show this help message and exit
+  --example EXAMPLE  Beispielparameter
+```
+
+## Debuggen
+
+- Lokales Debugging: Öffne das Projekt in deinem Editor/IDE und setze Breakpoints in `demo/src/main.py`.
+- Mit `python -m debugpy --listen 5678 -m demo.main` kann VS Code/IDE an Port 5678 verbinden.
+
+## Tests
+
+0) Installiere Abhängigkeiten (falls notwendig)
+
+```bash
+python -m pip install -e .
+# oder mit Poetry im generierten Projekt:
+poetry install --with dev
+```
+
+1) Tests ausführen
+
+```bash
+poetry run pytest -q
+```
+
+Erwartete Ausgabe (Beispiel):
+
+```
+============================= test session starts ==============================
+collected 3 items
+
+tests/test_main.py ...                                                     [100%]
+
+============================== 3 passed in 0.12s ===============================
+```
+
+## Packaging
+
+- Mit `python -m build` erzeugst du sdist und wheel (stellen Sie sicher, dass `build` installiert ist).
+- Mit Poetry:
+
+```bash
+poetry build
+```
+
+## Hinweise
+
+- Falls dein Zielprojekt Poetry verwendet, nutze `poetry run` für Befehle in der Entwicklungsumgebung.
+- Passe die Beispiele an das tatsächliche Package/Modul‑Naming des gerenderten Templates an (z. B. `demo.main`).
+
+<!-- EOF -->

--- a/project_templates/cli-basic/docs/index.md.jinja
+++ b/project_templates/cli-basic/docs/index.md.jinja
@@ -8,13 +8,41 @@ Dies ist die Beispiel‑Dokumentationsseite für das Template `cli-basic`.
 pip install -e .
 ```
 
-## Benutzung
+## CLI‑Flags (Starter Script)
 
-Starten Sie das Beispiel:
+Das Starter‑CLI (`python -m template_python_projekt`) unterstützt folgende Flags:
+
+- `--template` (required): Name des Templates, z. B. `cli-basic`.
+- `--name` (required): Name des zu erzeugenden Projekts.
+- `--dest` (optional): Zielverzeichnis. Default: `.`
+- `--dry-run` (flag): Keine Dateien schreiben; es werden die geplanten Aktionen ausgegeben.
+- `--force` (flag): Existierende Dateien überschreiben.
+
+Für jedes Flag gibt es in den Beispielaufrufen weiter unten ein konkretes Beispiel.
+
+## Beispiele
+
+1) Hilfe anzeigen
 
 ```bash
-python -m project_templates.cli_basic.src.main --help
+python -m template_python_projekt --help
 ```
+
+2) Dry‑Run eines Template‑Renders (keine Dateien werden geschrieben)
+
+```bash
+python -m template_python_projekt --template cli-basic --name demo --dry-run
+```
+
+Erwartete Ausgabe (Beispiel):
+
+```
+starter: template=cli-basic, name=demo, dest=., dry_run=True, force=False
+Would write: demo/README.md
+Would write: demo/src/__init__.py
+```
+
+Hinweis: Die exakten `Would write:` Pfade hängen vom Template‑Inhalt ab.
 
 ## Template‑Variablen
 - `project_name`: Name des Projekts

--- a/project_templates/cli-basic/docs/migration_example.md.jinja
+++ b/project_templates/cli-basic/docs/migration_example.md.jinja
@@ -1,0 +1,18 @@
+# Beispiel: README Merge‑Muster
+
+Wenn das Template eine neue `README.md` liefert, sollten projekt-spezifische
+Abschnitte erhalten bleiben. Vorgehen:
+
+1. Render die Template-README in ein temporäres Verzeichnis.
+2. Vergleiche die gerenderte Datei mit der existierenden `README.md`.
+3. Übernehme generische Template-Änderungen (z. B. Badges, CI‑Hinweise), aber
+   behalte Usage- und Beispielabschnitte des Zielprojekts.
+4. Dokumentiere alle übernommenen Änderungen im Commit-Text.
+
+Beispiel: Verwende `git` und `diff` zum Überprüfen:
+
+```bash
+git checkout -b migration/readme-update
+# render in /tmp/new_readme
+diff -u README.md /tmp/new_readme/README.md | less
+```

--- a/project_templates/common/migration_examples/pyproject_migration.md.jinja
+++ b/project_templates/common/migration_examples/pyproject_migration.md.jinja
@@ -1,0 +1,27 @@
+# Beispiel: `pyproject.toml` Migration
+
+Dieses Beispiel zeigt ein sicheres Vorgehen, um `pyproject.toml`-Änderungen
+in ein bestehendes Projekt zu übernehmen.
+
+1. Render die neue `pyproject.toml` in ein temporäres Verzeichnis.
+
+   ```bash
+   python -m template_python_projekt --render /tmp/new_project
+   ```
+
+2. Vergleiche die Abschnitte `tool.poetry.dependencies` und
+   `tool.poetry.dev-dependencies` mit einem diff-Tool.
+
+3. Übernimm nur die notwendigen Versions- oder Konfigurationsänderungen
+   manuell oder per Patch; behalte projektspezifische Anpassungen.
+
+4. Führe `poetry install` lokal in einer virtuellen Umgebung durch und
+   prüfe, ob Tests erfolgreich laufen.
+
+5. Committe Änderungen in einem separaten Branch und verifiziere Lint/Typechecks:
+
+```bash
+poetry run ruff check .
+poetry run mypy .
+poetry run pytest -q
+```

--- a/project_templates/ui-pyside6/README.md.jinja
+++ b/project_templates/ui-pyside6/README.md.jinja
@@ -1,0 +1,80 @@
+# {{ project_name }} — Beispiel: PySide6 UI
+
+Diese Datei beschreibt, wie man das generierte PySide6‑Beispielprojekt ausführt, debuggt, testet und paketiert.
+
+## Schnellstart — Ausführen
+
+1) Projekt generieren (Dry‑Run)
+
+```bash
+python -m template_python_projekt --template ui-pyside6 --name demo --dry-run
+```
+
+2) Projekt wirklich erzeugen
+
+```bash
+python -m template_python_projekt --template ui-pyside6 --name demo
+cd demo
+```
+
+3) UI starten
+
+```bash
+python -m demo.main
+```
+
+Erwartete Ausgabe / Verhalten (Beispiel):
+
+- Ein Fenster mit Titel "DemoApp" öffnet sich (oder eine kurze Konsolenausgabe, falls die Vorlage nur einen Headless‑Stub enthält).
+
+## Debuggen
+
+- Setze Breakpoints in `demo/src/main.py` oder `demo/src/view/`.
+- Remote‑Debugging mit `debugpy`:
+
+```bash
+python -m debugpy --listen 5678 -m demo.main
+```
+
+Dann in VS Code verbinden (Port 5678).
+
+## Tests
+
+0) Abhängigkeiten installieren
+
+```bash
+python -m pip install -e .
+# oder mit Poetry im generierten Projekt:
+poetry install --with dev
+```
+
+1) Tests ausführen
+
+```bash
+poetry run pytest -q
+```
+
+Erwartete Ausgabe (Beispiel):
+
+```
+============================= test session starts ==============================
+collected 2 items
+
+tests/test_ui_startup.py ..                                                  [100%]
+
+============================== 2 passed in 0.50s ===============================
+```
+
+Hinweis: UI‑Tests können Headless‑Modi oder Mocks erfordern; passe Tests entsprechend an.
+
+## Packaging
+
+- Mit `poetry build` erzeugst du wheel und sdist.
+- Für Desktop‑Distributionen nutze Tools wie `briefcase` oder `pyinstaller` (nicht Teil dieses Templates; Hinweise und Beispiele können hier ergänzt werden).
+
+## Hinweise
+
+- PySide6 sollte in der `pyproject.toml` oder `requirements.txt` des generierten Projekts als Abhängigkeit angegeben werden.
+- Wenn das Template nur einen Stub als `main` liefert, ergänze die `view/`‑Implementierung mit einem einfachen `QMainWindow`‑Beispiel für Demo‑Zwecke.
+
+<!-- EOF -->

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -1,0 +1,15 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Running check script (PowerShell)..."
+
+poetry env check
+poetry run pytest -q
+pre-commit run --all-files
+
+if (Test-Path -Path "./package.json") {
+    Write-Host "Found package.json — running npm run lint:md"
+    npm run lint:md
+} else {
+    Write-Host "No package.json found — skipping npm lint"
+}

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running check script (Unix shell)..."
+
+poetry env check
+poetry run pytest -q
+pre-commit run --all-files
+
+if [ -f package.json ]; then
+  echo "Found package.json — running npm run lint:md"
+  npm run lint:md || true
+else
+  echo "No package.json found — skipping npm lint"
+fi

--- a/src/template_python_projekt/main.py
+++ b/src/template_python_projekt/main.py
@@ -27,6 +27,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dest", default=".", help="Destination directory")
     p.add_argument("--dry-run", action="store_true", help="Show actions without writing files")
     p.add_argument("--force", action="store_true", help="Overwrite existing files if necessary")
+    p.add_argument(
+        "--update-mode",
+        choices=["backup", "skip", "overwrite"],
+        default="backup",
+        help="Update strategy when target files exist (default: backup)",
+    )
     return p
 
 
@@ -43,12 +49,16 @@ def main(argv: list[str] | None = None) -> int:
 
     if render and hasattr(render, "render_project"):
         try:
+            # Map legacy --force to update_mode=overwrite
+            if args.force:
+                args.update_mode = "overwrite"
+
             render.render_project(
                 template_name=args.template,
                 project_name=args.name,
                 dest=args.dest,
                 dry_run=args.dry_run,
-                force=args.force,
+                update_mode=args.update_mode,
             )
         except Exception as exc:  # noqa: BLE001 - top-level CLI should report unexpected errors
             print(f"Error: {exc}", file=sys.stderr)

--- a/src/template_python_projekt/render.py
+++ b/src/template_python_projekt/render.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import tempfile
 import tomllib
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -96,7 +97,7 @@ def _prepare_plan(
     rendered: dict[str, str],
     dest_root: Path,
     *,
-    force: bool,
+    update_mode: str,
 ) -> tuple[dict[str, str], list[str]]:
     """Erzeuge das `planned`-Mapping und Liste von Konflikten.
 
@@ -105,20 +106,32 @@ def _prepare_plan(
     """
     planned: dict[str, str] = {}
     conflicts: list[str] = []
+    if update_mode not in {"backup", "skip", "overwrite"}:
+        raise ValueError("unsupported update_mode: " + str(update_mode))
+
     for rel, content in rendered.items():
         target = dest_root / rel
         # Entferne .jinja Suffix falls vorhanden
         if target.suffix == ".jinja":
             target = target.with_suffix("")
+
+        # Wenn Datei schon existiert und wir 'skip' gewählt haben, dann
+        # planen wir keine Änderung für diese Datei.
+        if target.exists() and update_mode == "skip":
+            continue
+
         planned[str(target)] = content
-        if target.exists() and not force:
+        # Konflikte werden nicht als Fehler behandelt, Update-Strategie steuert Verhalten
+        if target.exists():
             conflicts.append(str(target))
+
     return planned, conflicts
 
 
 def _backup_existing(p: Path, backup_dir: str) -> None:
     if p.exists():
-        bpath = Path(backup_dir) / (p.name + ".bak")
+        ts = datetime.now().astimezone().strftime("%Y%m%d%H%M%S")
+        bpath = Path(backup_dir) / (p.name + f".bak.{ts}")
         shutil.copy2(p, bpath)
 
 
@@ -154,7 +167,7 @@ def render_project(
     dest: str | Path = ".",
     *,
     dry_run: bool = False,
-    force: bool = False,
+    update_mode: str = "backup",
 ) -> dict[str, str]:
     """Render ein Template-Projekt in *project_templates/<template_name>/src*.
 
@@ -174,17 +187,14 @@ def render_project(
     rendered = render_directory(template_dir, {"name": project_name})
 
     dest_root = Path(dest) / project_name
-    planned, conflicts = _prepare_plan(rendered, dest_root, force=force)
-
-    if conflicts:
-        raise FileExistsError("Conflicting files exist: " + ", ".join(conflicts))
+    planned, _conflicts = _prepare_plan(rendered, dest_root, update_mode=update_mode)
 
     if dry_run:
         for t in planned:
             print("Would write:", t)
         return planned
 
-    # Schreibe die Dateien tatsächlich mit Backup und atomaren Writes.
+    # Schreibe die Dateien tatsächlich mit Backup-Strategie und atomaren Writes.
     backup_dir = tempfile.mkdtemp(prefix="tpl_backup_")
 
     created_files: list[str] = []
@@ -194,8 +204,12 @@ def render_project(
             p = Path(t)
             p.parent.mkdir(parents=True, exist_ok=True)
 
+            # Falls Datei existiert und Update-Mode == 'skip', haben wir sie
+            # bereits aus `planned` gefiltert. Hier behandeln wir Backup vs Overwrite.
             if p.exists():
-                _backup_existing(p, backup_dir)
+                if update_mode == "backup":
+                    _backup_existing(p, backup_dir)
+                # overwrite -> einfach überschreiben (kein Backup)
             else:
                 created_files.append(str(p))
 

--- a/tests/test_migration_docs.py
+++ b/tests/test_migration_docs.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_migration_docs_content() -> None:
+    """Validate that the migration docs contain key sections and commands."""
+    p = Path("docs") / "migration_and_updates.md"
+    assert p.exists(), "docs/migration_and_updates.md must exist"
+    content = p.read_text(encoding="utf-8")
+    assert "## Schnell-Checkliste" in content
+    assert "poetry run pytest -q" in content
+    assert "--update-mode" in content or "update-mode" in content

--- a/tests/test_render_update_mode.py
+++ b/tests/test_render_update_mode.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from template_python_projekt import render
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def test_render_update_mode_skip_overwrite_and_backup(tmp_path):
+    # Prepare an existing project file that would conflict with template
+    project_name = "projx"
+    dest = tmp_path
+    dest_root = dest / project_name
+    dest_root.mkdir(parents=True)
+    target_file = dest_root / "main.py"
+    target_file.write_text("# ORIGINAL\n", encoding="utf-8")
+
+    # Ensure skip keeps original content
+    render.render_project("cli-basic", project_name, dest, dry_run=False, update_mode="skip")
+    assert _read(target_file).startswith("# ORIGINAL")
+
+    # Overwrite replaces content with template content
+    render.render_project("cli-basic", project_name, dest, dry_run=False, update_mode="overwrite")
+    content_after_overwrite = _read(target_file)
+    assert not content_after_overwrite.startswith("# ORIGINAL")
+    assert "Minimal CLI entrypoint" in content_after_overwrite or "def create_parser" in content_after_overwrite
+
+    # Backup mode also writes the new content (and would backup the old one internally)
+    target_file.write_text("# ORIGINAL2\n", encoding="utf-8")
+    render.render_project("cli-basic", project_name, dest, dry_run=False, update_mode="backup")
+    content_after_backup = _read(target_file)
+    assert not content_after_backup.startswith("# ORIGINAL2")

--- a/tests/test_template_cli_basic.py
+++ b/tests/test_template_cli_basic.py
@@ -16,3 +16,9 @@ def test_missing_required_args_fails() -> None:
     # missing --template and --name should cause non-zero exit (argparse)
     r = _run([])
     assert r.returncode != 0
+
+
+def test_example_dry_run() -> None:
+    r = _run(["--template", "cli-basic", "--name", "demo", "--dry-run"])
+    assert r.returncode == 0
+    assert "Would write:" in r.stdout

--- a/tests/test_troubleshooting_doc.py
+++ b/tests/test_troubleshooting_doc.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_troubleshooting_doc_exists_and_contains_keywords() -> None:
+    p = Path("docs/troubleshooting.md")
+    assert p.exists(), "docs/troubleshooting.md fehlt"
+    text = p.read_text(encoding="utf-8")
+    for kw in ("poetry", "node", "pre-commit", "merge"):
+        assert kw in text, f"Schlüsselwort '{kw}' nicht in docs/troubleshooting.md gefunden"


### PR DESCRIPTION
Zusammenfassung

Dieses PR fasst die Arbeit für Issue #5 zusammen und ergänzt die Dokumentation sowie die Starter‑Tooling-Implementierung, damit ein neues Projekt aus den Vorlagen auf einer frischen Maschine reproduzierbar erzeugt und verifiziert werden kann.

Änderungen (übersicht)

- Detaillierte Quickstart‑Anleitung: `docs/quickstart.md`
- Schritt‑für‑Schritt manuelle Initialisierung: `docs/manual_initialization.md`
- Troubleshooting & FAQ ergänzt: `docs/troubleshooting.md`
- CONTRIBUTING Guide aktualisiert: `CONTRIBUTING.md`
- Beispiel‑Templates und Jinja‑Vorlagen ergänzt/überarbeitet: `project_templates/*`
- Scripts für Checks hinzugefügt: `scripts/check.ps1`, `scripts/check.sh`
- Starter‑CLI und Renderer: `src/template_python_projekt/main.py`, `src/template_python_projekt/render.py`
- Tests hinzugefügt/aktualisiert (Deckung für neues Verhalten): `tests/*`
- Diverse Prompt/Plan Dateien unter `.github/prompts/` für Dokumentations‑Workflows

Motivation

Ziel ist, dass ein Entwickler auf einer frischen Maschine mit installierten Voraussetzungen in wenigen Schritten ein „ready to use“ Projekt erzeugen, lokal prüfen und sofort weiterentwickeln kann. Die Dokumente enthalten reproduzierbare Befehle und Troubleshooting‑Hinweise.

Akzeptanzkriterien (aus Issue #5)

- Quickstart reproduziert ein vollständiges "ready to use" Projekt auf einer frischen Maschine mit installierten Voraussetzungen.
- Detaillierte Dokumentation für Starterskript‑Nutzung, manuelle Initialisierung, Troubleshooting und Contribution sind vorhanden.

Verifikation / Testanweisungen

Lokale Verifikation (im Repo‑Root):

```bash
poetry install --with dev
poetry run ruff check .
poetry run mypy .
poetry run pytest -q
```

Die Test‑Suite läuft lokal grün (25 passed).

Weitere Hinweise

- Alle Änderungen sind auf Branch `issue/5` beschränkt; `main` wurde nicht verändert.
- Die Renderer‑Implementierung enthält einen Fallback, falls `jinja2` nicht installiert ist; empfohlen wird die Nutzung von `poetry` und einer dev‑Umgebung.

Bitte prüfen und bei Zustimmung mergen. Falls du möchtest, kann ich nach dem Merge noch ein kurzes Release‑Note‑Update in `CHANGELOG.md` vorschlagen.
